### PR TITLE
Make Soldeer dependency install part of make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,11 @@ load_prod_env:
 clean:
 	@forge clean
 
-build:
+# Install dependency contracts with soldeer
+deps:
+	@soldeer install
+
+build: deps
 	@forge build
 
 clean-docker:


### PR DESCRIPTION
- Soldeer dependencies were not explicitly inthe  instructions or part of the Makefile process
- Added `make deps` step needed for `make build`, so that build will pass cleanly on the first time