### PR TITLE
refactor: rename WhitelistState to AccessMode

### DIFF
--- a/src/v0.6.0/Whitelistable.sol
+++ b/src/v0.6.0/Whitelistable.sol
@@ -5,7 +5,7 @@ import {Roles} from "./Roles.sol";
 import {SanctionsList} from "./interfaces/SanctionsList.sol";
 import {RolesLib} from "./libraries/RolesLib.sol";
 import {WhitelistableLib} from "./libraries/WhitelistableLib.sol";
-import {WhitelistState} from "./primitives/Enums.sol";
+import {AccessMode} from "./primitives/Enums.sol";
 
 abstract contract Whitelistable is Roles {
     /// @custom:storage-definition erc7201:hopper.storage.Whitelistable
@@ -13,29 +13,29 @@ abstract contract Whitelistable is Roles {
     /// @param isActivated The flag to check if the whitelist is activated.
     struct WhitelistableStorage {
         mapping(address => bool) isWhitelisted;
-        // in v0.6.0, we replace the bool isActivated with a enum WhitelistState
-        // bool isActivated; --> WhitelistState whitelistState;
-        WhitelistState whitelistState;
+        // in v0.6.0, we replace the bool isActivated with a enum AccessMode
+        // bool isActivated; --> AccessMode accessMode;
+        AccessMode accessMode;
         // added in v0.6.0
         mapping(address => bool) isBlacklisted;
         SanctionsList externalSanctionList;
     }
 
     /// @dev Initializes the whitelist.
-    /// @param whitelistState the state of the whitelist.
+    /// @param accessMode the access mode of the whitelist.
     // solhint-disable-next-line func-name-mixedcase
     function __Whitelistable_init(
-        WhitelistState whitelistState,
+        AccessMode accessMode,
         address externalSanctionsList
     ) internal onlyInitializing {
-        WhitelistableLib.switchWhitelistMode(whitelistState);
+        WhitelistableLib.switchAccessMode(accessMode);
         WhitelistableLib.setExternalSanctionsList(SanctionsList(externalSanctionsList));
     }
 
-    function switchWhitelistMode(
-        WhitelistState newMode
+    function switchAccessMode(
+        AccessMode newMode
     ) public onlyOwner {
-        WhitelistableLib.switchWhitelistMode(newMode);
+        WhitelistableLib.switchAccessMode(newMode);
     }
 
     /// @notice Checks if an account is whitelisted or blacklisted
@@ -113,12 +113,12 @@ abstract contract Whitelistable is Roles {
 //   |                           32 bytes                            |
 // Note: The actual mapping data is stored at keccak256(key . slot)
 
-// slot 1: whitelistState
-// Type: enum WhitelistState (uint8)
-// Description: Whitelist state enum value (only 1 byte used, right-aligned)
+// slot 1: accessMode
+// Type: enum AccessMode (uint8)
+// Description: Access mode enum value (only 1 byte used, right-aligned)
 // Possible values: 0x00 (BlacklistMode), 0x01 (WhitelistMode), 0x02 (Deactivated), etc.
 // Visual representation (bytes32):
-//                                                          whitelistState
+//                                                          accessMode
 // 0x0000000000000000000000000000000000000000000000000000000000000001
 //   |                      31 bytes unused                      |xx|
 //                                                               (1 byte)
@@ -134,10 +134,10 @@ abstract contract Whitelistable is Roles {
 // Upgrades scenario:
 // we upgrade the whitelistable contract from v0.5.0 to v0.6.0
 // 1) isActivated is 0 (deactivated)
-//   1.1) whitelistState is 0 (blacklist)
+//   1.1) accessMode is 0 (blacklist)
 // --> vault remains as accessible as before the upgrade
 //     if the admin wants to disable the blacklist, he can call the disableWhitelist function
 // 2) isActivated is 1 (activated)
-//   2.1) whitelistState is 1 (whitelist)
+//   2.1) accessMode is 1 (whitelist)
 // --> vault remains in whitelist mode
 //     if the admin wants to disable the whitelist, he can call the disableWhitelist function

--- a/src/v0.6.0/libraries/WhitelistableLib.sol
+++ b/src/v0.6.0/libraries/WhitelistableLib.sol
@@ -3,13 +3,11 @@ pragma solidity 0.8.26;
 
 import {Whitelistable} from "../Whitelistable.sol";
 import {SanctionsList} from "../interfaces/SanctionsList.sol";
-import {WhitelistState} from "../primitives/Enums.sol";
-import {AccessControlDisabled} from "../primitives/Errors.sol";
+import {AccessMode} from "../primitives/Enums.sol";
 import {
-    BlacklistActivated,
+    AccessModeUpdated,
     BlacklistUpdated,
     ExternalSanctionsListUpdated,
-    WhitelistActivated,
     WhitelistDisabled,
     WhitelistUpdated
 } from "../primitives/Events.sol";
@@ -98,22 +96,16 @@ library WhitelistableLib {
         }
     }
 
-    /// @notice Switches the whitelist mode
-    /// @param newMode The new whitelist mode
-    /// @dev If the whitelist is switched to blacklist, it emits a BlacklistActivated event
-    /// @dev If the whitelist is switched to whitelist, it emits a WhitelistActivated event
-    /// event
-    function switchWhitelistMode(
-        WhitelistState newMode
+    /// @notice Switches the access mode
+    /// @param newMode The new access mode
+    /// @dev Emits an AccessModeUpdated event with the new mode
+    function switchAccessMode(
+        AccessMode newMode
     ) public {
         Whitelistable.WhitelistableStorage storage $ = _getWhitelistableStorage();
 
-        $.whitelistState = newMode;
-        if (newMode == WhitelistState.Blacklist) {
-            emit BlacklistActivated();
-        } else if (newMode == WhitelistState.Whitelist) {
-            emit WhitelistActivated();
-        }
+        $.accessMode = newMode;
+        emit AccessModeUpdated(newMode);
     }
 
     /// @notice Sets the external sanctions list
@@ -133,7 +125,7 @@ library WhitelistableLib {
         address account
     ) public view returns (bool) {
         Whitelistable.WhitelistableStorage storage $ = _getWhitelistableStorage();
-        WhitelistState _whitelistState = $.whitelistState;
+        AccessMode _accessMode = $.accessMode;
 
         if (RolesLib._getRolesStorage().feeRegistry.protocolFeeReceiver() == account) {
             // if the account is the protocol fee receiver, it is always whitelisted
@@ -142,7 +134,7 @@ library WhitelistableLib {
         // if the whitelist is active, we check if the account is whitelisted
         // if the whitelist is in blacklist mode and the account is blacklisted we return false
         bool internalListApproval =
-            _whitelistState == WhitelistState.Whitelist ? $.isWhitelisted[account] : !$.isBlacklisted[account];
+            _accessMode == AccessMode.Whitelist ? $.isWhitelisted[account] : !$.isBlacklisted[account];
 
         // by default, we consider that the external sanctions list is not set, so we set it to true
         bool externalListApproval = true;

--- a/src/v0.6.0/primitives/Enums.sol
+++ b/src/v0.6.0/primitives/Enums.sol
@@ -10,7 +10,7 @@ enum State {
 }
 
 // ********************* WHITELISTABLE ********************* //
-enum WhitelistState {
+enum AccessMode {
     Blacklist,
     Whitelist
 }

--- a/src/v0.6.0/primitives/Errors.sol
+++ b/src/v0.6.0/primitives/Errors.sol
@@ -85,10 +85,3 @@ error OnlyValuationManager(address valuationManager);
 
 /// @notice Indicates that the caller is not whitelisted.
 error NotWhitelisted();
-
-/// @notice Indicates that the whitelist is not activated.
-/// @dev this error is not used in v0.6.0.
-error WhitelistNotActivated();
-
-/// @notice Indicates that the whitelist/blacklist is disabled.
-error AccessControlDisabled();

--- a/src/v0.6.0/primitives/Events.sol
+++ b/src/v0.6.0/primitives/Events.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.26;
 
-import {FeeType, State, WhitelistState} from "./Enums.sol";
+import {AccessMode, FeeType, State} from "./Enums.sol";
 import {Rates} from "./Struct.sol";
 
 // ********************* VAULT ********************* //
@@ -131,9 +131,7 @@ event TotalAssetsLifespanUpdated(uint128 oldLifespan, uint128 newLifespan);
 /// @param shares Amount of shares minted to owner
 event DepositSync(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
 
-/// @notice Emitted when the whitelist is switched to blacklist.
-event BlacklistActivated();
-
-/// @notice Emitted when the whitelist is switched to whitelist.
-event WhitelistActivated();
+/// @notice Emitted when the access mode is updated.
+/// @param newMode The new access mode (Blacklist or Whitelist).
+event AccessModeUpdated(AccessMode newMode);
 

--- a/src/v0.6.0/vault/Vault-v0.6.0.sol
+++ b/src/v0.6.0/vault/Vault-v0.6.0.sol
@@ -14,7 +14,7 @@ import {VaultInit} from "./VaultInit.sol";
 import {FeeManager} from "../FeeManager.sol";
 import {Roles} from "../Roles.sol";
 import {Whitelistable} from "../Whitelistable.sol";
-import {State, WhitelistState} from "../primitives/Enums.sol";
+import {AccessMode, State} from "../primitives/Enums.sol";
 import {
     CantDepositNativeToken,
     Closed,
@@ -52,7 +52,7 @@ using Math for uint256;
 /// @param managementRate The management fee rate.
 /// @param performanceRate The performance fee rate.
 /// @param rateUpdateCooldown The cooldown period for updating the fee rates.
-/// @param enableWhitelist A boolean indicating whether the whitelist is enabled.
+/// @param accessMode The access mode (Whitelist or Blacklist).
 struct InitStruct {
     IERC20 underlying;
     string name;
@@ -64,7 +64,7 @@ struct InitStruct {
     address feeReceiver;
     uint16 managementRate;
     uint16 performanceRate;
-    WhitelistState whitelistState;
+    AccessMode accessMode;
     uint256 rateUpdateCooldown;
     address externalSanctionsList;
 }

--- a/src/v0.6.0/vault/VaultInit.sol
+++ b/src/v0.6.0/vault/VaultInit.sol
@@ -5,7 +5,7 @@ import {ERC7540} from "../ERC7540.sol";
 import {FeeManager} from "../FeeManager.sol";
 import {Roles} from "../Roles.sol";
 import {Whitelistable} from "../Whitelistable.sol";
-import {State, WhitelistState} from "../primitives/Enums.sol";
+import {AccessMode, State} from "../primitives/Enums.sol";
 import {
     CantDepositNativeToken,
     Closed,
@@ -41,7 +41,7 @@ using SafeERC20 for IERC20;
 /// @param wrappedNativeToken The address of the wrapped native token.
 /// @param managementRate The management fee rate.
 /// @param performanceRate The performance fee rate.
-/// @param whitelistState The state of the whitelist.
+/// @param accessMode The access mode (Whitelist or Blacklist).
 /// @param entryRate The entry fee rate.
 /// @param exitRate The exit fee rate.
 struct InitStruct {
@@ -55,7 +55,7 @@ struct InitStruct {
     address feeReceiver;
     uint16 managementRate;
     uint16 performanceRate;
-    WhitelistState whitelistState;
+    AccessMode accessMode;
     // added in v0.6.0
     uint16 entryRate;
     uint16 exitRate;
@@ -93,7 +93,7 @@ contract VaultInit is ERC7540, Whitelistable, FeeManager {
         __ERC20Pausable_init();
         __ERC4626_init(init.underlying);
         __ERC7540_init(init.underlying, wrappedNativeToken);
-        __Whitelistable_init(init.whitelistState, address(0));
+        __Whitelistable_init(init.accessMode, address(0));
         __FeeManager_init({
             _registry: feeRegistry,
             _managementRate: init.managementRate,

--- a/test/v0.6.0/VaultHelper.sol
+++ b/test/v0.6.0/VaultHelper.sol
@@ -39,11 +39,11 @@ contract VaultHelper is Vault {
     /// @notice Returns if the whitelist is activated
     /// @return True if the whitelist is activated, false otherwise
     function isWhitelistActivated() public view returns (bool) {
-        return WhitelistableLib._getWhitelistableStorage().whitelistState == WhitelistState.Whitelist;
+        return WhitelistableLib._getWhitelistableStorage().accessMode == AccessMode.Whitelist;
     }
 
     function isBlacklistActivated() public view returns (bool) {
-        return WhitelistableLib._getWhitelistableStorage().whitelistState == WhitelistState.Blacklist;
+        return WhitelistableLib._getWhitelistableStorage().accessMode == AccessMode.Blacklist;
     }
 
     function totalAssets(
@@ -168,7 +168,7 @@ contract VaultHelper is Vault {
     }
 
     function activateWhitelist() public {
-        WhitelistableLib._getWhitelistableStorage().whitelistState = WhitelistState.Whitelist;
+        WhitelistableLib._getWhitelistableStorage().accessMode = AccessMode.Whitelist;
     }
 
     function protocolFeeReceiver() public view returns (address) {

--- a/test/v0.6.0/Whitelist.t.sol
+++ b/test/v0.6.0/Whitelist.t.sol
@@ -7,7 +7,7 @@ import "forge-std/Test.sol";
 import {BaseTest} from "./Base.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {SanctionsList} from "@src/v0.6.0/interfaces/SanctionsList.sol";
-import {WhitelistState} from "@src/v0.6.0/primitives/Enums.sol";
+import {AccessMode} from "@src/v0.6.0/primitives/Enums.sol";
 
 contract TestWhitelist is BaseTest {
     address constant EXTERNAL_SANCTIONS_LIST = 0x40C57923924B5c5c5455c48D93317139ADDaC8fb;
@@ -80,7 +80,7 @@ contract TestWhitelist is BaseTest {
         deposit(userBalance, user1.addr);
         address receiver = user2.addr;
         vm.prank(vault.owner());
-        vault.switchWhitelistMode(WhitelistState.Blacklist);
+        vault.switchAccessMode(AccessMode.Blacklist);
         vm.assertEq(vault.isBlacklistActivated(), true);
         vm.assertEq(vault.isWhitelistActivated(), false);
         uint256 shares = vault.balanceOf(user1.addr);
@@ -221,7 +221,7 @@ contract TestWhitelist is BaseTest {
 
         // Ensure we're in Whitelist mode
         vm.prank(vault.owner());
-        vault.switchWhitelistMode(WhitelistState.Whitelist);
+        vault.switchAccessMode(AccessMode.Whitelist);
 
         // Manually whitelist the sanctioned address
         address[] memory accounts = new address[](1);
@@ -245,7 +245,7 @@ contract TestWhitelist is BaseTest {
 
         // Switch to Blacklist mode
         vm.prank(vault.owner());
-        vault.switchWhitelistMode(WhitelistState.Blacklist);
+        vault.switchAccessMode(AccessMode.Blacklist);
 
         // We make sure that the sanctioned address is blacklisted
         assertFalse(

--- a/test/v0.6.0/storageCollisions/Whitelistable.t.sol
+++ b/test/v0.6.0/storageCollisions/Whitelistable.t.sol
@@ -22,7 +22,7 @@
 
 // contract WhitelistableStorageV0_6_0 {
 //     mapping(address => bool) public isWhitelisted;
-//     WhitelistState public whitelistState;
+//     AccessMode public accessMode;
 //     mapping(address => bool) public isBlacklisted;
 // }
 


### PR DESCRIPTION
- Rename enum WhitelistState to AccessMode
- Rename function switchWhitelistMode to switchAccessMode
- Replace BlacklistActivated and WhitelistActivated events with single AccessModeUpdated(AccessMode) event
- Remove unused errors WhitelistNotActivated and AccessControlDisabled

Addresses review comments from PR #269.