### PR TITLE
fix: address PR #270 review comments

### DIFF
--- a/src/protocol-v3/OptinProxyFactory.sol
+++ b/src/protocol-v3/OptinProxyFactory.sol
@@ -2,9 +2,8 @@
 pragma solidity 0.8.26;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {LagoonVault} from "@src/proxy/OptinProxy.sol";
-import {AccessMode} from "@src/v0.6.0/primitives/Enums.sol";
+import {InitStruct} from "@src/v0.6.0/vault/Vault-v0.6.0.sol";
 
 interface IVault {
     function initialize(
@@ -24,42 +23,6 @@ struct OptinProxyFactoryStorage {
     address WRAPPED_NATIVE;
     /// @notice Mapping to track whether an address is a proxy instance created by this factory
     mapping(address => bool) isInstance;
-}
-
-/// @title InitStruct
-/// @notice Initialization structure for creating new vault proxies
-/// @dev Contains all necessary parameters to initialize a vault
-struct InitStruct {
-    /// @notice Underlying ERC20 token for the vault
-    IERC20 underlying;
-    /// @notice Name of the vault token
-    string name;
-    /// @notice Symbol of the vault token
-    string symbol;
-    /// @notice Address of the safe/multisig
-    address safe;
-    /// @notice Address of the whitelist manager
-    address whitelistManager;
-    /// @notice Address of the valuation manager
-    address valuationManager;
-    /// @notice Admin address for the vault
-    address admin;
-    /// @notice Fee receiver address
-    address feeReceiver;
-    /// @notice Management fee rate (in basis points)
-    uint16 managementRate;
-    /// @notice Performance fee rate (in basis points)
-    uint16 performanceRate;
-    /// @notice Access mode (Whitelist or Blacklist)
-    AccessMode accessMode;
-    /// @notice Entry fee rate (in basis points)
-    uint16 entryRate;
-    /// @notice Exit fee rate (in basis points)
-    uint16 exitRate;
-    /// @notice Address of the security council
-    address securityCouncil;
-    /// @notice Address of the external sanctions list
-    address externalSanctionsList;
 }
 
 /// @title OptinProxyFactory

--- a/src/protocol-v3/OptinProxyFactory.sol
+++ b/src/protocol-v3/OptinProxyFactory.sol
@@ -75,6 +75,7 @@ contract OptinProxyFactory is OwnableUpgradeable {
         $.WRAPPED_NATIVE = _wrappedNativeToken;
     }
 
+    /// @param _logic Address of the vault logic implementation
     /// @param _initialOwner Address of the initial proxy owner
     /// @param _initialDelay The initial delay before which an upgrade can occur by the proxy admin
     /// @param _init Initialization parameters for the vault

--- a/src/v0.5.0/Vault.sol
+++ b/src/v0.5.0/Vault.sol
@@ -18,13 +18,13 @@ import {
     ValuationUpdateNotAllowed
 } from "./primitives/Errors.sol";
 
-import {FeeRegistry} from "../protocol-v1/FeeRegistry.sol";
 import {DepositSync, Referral, StateUpdated} from "./primitives/Events.sol";
 import {ERC4626Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {FeeRegistry} from "@src/protocol-v1/FeeRegistry.sol";
 
 using SafeERC20 for IERC20;
 
@@ -59,6 +59,7 @@ struct InitStruct {
 }
 
 /// @custom:contact team@hopperlabs.xyz
+/// @custom:oz-upgrades-from src/v0.4.0/Vault.sol:Vault
 contract Vault is ERC7540, Whitelistable, FeeManager {
     /// @custom:storage-location erc7201:hopper.storage.vault
     /// @param newTotalAssets The new total assets of the vault. It is used to update the totalAssets variable.

--- a/src/v0.6.0/FeeManager.sol
+++ b/src/v0.6.0/FeeManager.sol
@@ -51,6 +51,7 @@ abstract contract FeeManager is Ownable2StepUpgradeable {
     /// @param _decimals the number of decimals of the shares
     /// @param _entryRate the entry fee rate, expressed in BPS
     /// @param _exitRate the exit fee rate, expressed in BPS
+    /// @param _haircutRate the haircut fee rate, expressed in BPS
     // solhint-disable-next-line func-name-mixedcase
     function __FeeManager_init(
         address _registry,
@@ -58,7 +59,8 @@ abstract contract FeeManager is Ownable2StepUpgradeable {
         uint16 _performanceRate,
         uint256 _decimals,
         uint16 _entryRate,
-        uint16 _exitRate
+        uint16 _exitRate,
+        uint16 _haircutRate
     ) internal onlyInitializing {
         FeeManagerStorage storage $ = FeeLib._getFeeManagerStorage();
         FeeLib.updateRates(
@@ -68,7 +70,7 @@ abstract contract FeeManager is Ownable2StepUpgradeable {
                 performanceRate: _performanceRate,
                 entryRate: _entryRate,
                 exitRate: _exitRate,
-                haircutRate: 0 // ????????????
+                haircutRate: _haircutRate
             })
         );
 

--- a/src/v0.6.0/GuardRailsManager.sol
+++ b/src/v0.6.0/GuardRailsManager.sol
@@ -40,7 +40,8 @@ abstract contract GuardrailsManager is Roles {
         });
     }
 
-    // @inheritdoc GuardrailsLib
+    /// @notice Updates the current guardrails policy with a new one.
+    /// @param guardrails_ The new guardrails to be set.
     function updateGuardrails(
         Guardrails calldata guardrails_
     ) external onlySecurityCouncil {

--- a/src/v0.6.0/Roles.sol
+++ b/src/v0.6.0/Roles.sol
@@ -25,7 +25,7 @@ abstract contract Roles is Ownable2StepUpgradeable {
     /// @param feeRegistry The address of the FeeRegistry contract.
     /// @param valuationManager This address is responsible of updating the newTotalAssets value of the vault.
     /// @param securityCouncil The address of the security council that can update total assets without guardrails.
-    /// @param owner The address of the owner of the contract. It considered as the admin. It is not visible in the
+    /// @dev owner The address of the owner of the contract. It considered as the admin. It is not visible in the
     /// struct. It can change the others roles and itself. Initiate the fund closing. Disable the whitelist.
     struct RolesStorage {
         address whitelistManager;

--- a/src/v0.6.0/Roles.sol
+++ b/src/v0.6.0/Roles.sol
@@ -2,12 +2,7 @@
 pragma solidity 0.8.26;
 
 import {RolesLib} from "./libraries/RolesLib.sol";
-import {
-    OnlySafe,
-    OnlyValuationManagerOrSecurityCouncil,
-    OnlyWhitelistManager,
-    SafeUpgradeabilityNotAllowed
-} from "./primitives/Errors.sol";
+import {OnlySafe, OnlyWhitelistManager, SafeUpgradeabilityNotAllowed} from "./primitives/Errors.sol";
 import {
     FeeReceiverUpdated,
     SafeUpdated,
@@ -28,7 +23,8 @@ abstract contract Roles is Ownable2StepUpgradeable {
     /// @param safe Every lagoon vault is associated with a Safe smart contract. This address will receive the assets of
     /// the vault and can settle deposits and redeems.
     /// @param feeRegistry The address of the FeeRegistry contract.
-    /// @param valuationManager. This address is responsible of updating the newTotalAssets value of the vault.
+    /// @param valuationManager This address is responsible of updating the newTotalAssets value of the vault.
+    /// @param securityCouncil The address of the security council that can update total assets without guardrails.
     /// @param owner The address of the owner of the contract. It considered as the admin. It is not visible in the
     /// struct. It can change the others roles and itself. Initiate the fund closing. Disable the whitelist.
     struct RolesStorage {
@@ -75,8 +71,8 @@ abstract contract Roles is Ownable2StepUpgradeable {
     }
 
     /// @dev Modifier to check if the caller is the valuation manager.
-    modifier onlyValuationManagerOrSecurityCouncil() {
-        RolesLib._onlyValuationManagerOrSecurityCouncil();
+    modifier onlyValuationManager() {
+        RolesLib._onlyValuationManager();
         _;
     }
 

--- a/src/v0.6.0/Whitelistable.sol
+++ b/src/v0.6.0/Whitelistable.sol
@@ -10,7 +10,7 @@ import {AccessMode} from "./primitives/Enums.sol";
 abstract contract Whitelistable is Roles {
     /// @custom:storage-definition erc7201:hopper.storage.Whitelistable
     /// @param isWhitelisted The mapping of whitelisted addresses.
-    /// @param whitelistState The current whitelist mode (whitelist or blacklist).
+    /// @param accessMode The current access mode (whitelist or blacklist).
     struct WhitelistableStorage {
         mapping(address => bool) isWhitelisted;
         // in v0.6.0, we replace the bool isActivated with a enum AccessMode

--- a/src/v0.6.0/libraries/FeeLib.sol
+++ b/src/v0.6.0/libraries/FeeLib.sol
@@ -46,7 +46,7 @@ library FeeLib {
     /// @param assets the total assets under management
     /// @param annualRate the management rate, expressed in BPS and corresponding to the annual
     /// @param timeElapsed the time elapsed since the last fee calculation in seconds
-    /// @return managementFee the management fee express in assets
+    /// @return managementFee the management fee expressed in assets
     function calculateManagementFee(
         uint256 assets,
         uint256 annualRate,

--- a/src/v0.6.0/libraries/FeeLib.sol
+++ b/src/v0.6.0/libraries/FeeLib.sol
@@ -25,8 +25,8 @@ library FeeLib {
     uint16 constant MAX_PERFORMANCE_RATE = 5000; // 50 %
     uint16 constant MAX_ENTRY_RATE = 1000; // 10 %
     uint16 constant MAX_EXIT_RATE = 1000; // 10 %
-    uint16 constant MAX_HAIRCUT_RATE = 1000; // 10 %
     uint16 constant MAX_PROTOCOL_RATE = 3000; // 30 %
+    uint16 constant MAX_HAIRCUT_RATE = 1000; // 10 %
 
     // keccak256(abi.encode(uint256(keccak256("hopper.storage.FeeManager")) - 1)) & ~bytes32(uint256(0xff));
     /// @custom:storage-location erc7201:hopper.storage.FeeManager
@@ -226,6 +226,9 @@ library FeeLib {
         }
         if (newRates.exitRate > MAX_EXIT_RATE) {
             revert AboveMaxRate(MAX_EXIT_RATE);
+        }
+        if (newRates.haircutRate > MAX_HAIRCUT_RATE) {
+            revert AboveMaxRate(MAX_HAIRCUT_RATE);
         }
 
         Rates memory currentRates = $.rates;

--- a/src/v0.6.0/libraries/GuardrailsLib.sol
+++ b/src/v0.6.0/libraries/GuardrailsLib.sol
@@ -14,7 +14,7 @@ library GuardrailsLib {
     // scale to avoid loss of precision
     uint256 public constant SCALE = 1e18;
 
-    /// @custom:storage-definition erc7201:hopper.storage.FeeManager
+    /// @custom:storage-definition erc7201:hopper.storage.GuardrailsManager
     /// @param guardrails The current guardrails.
     struct GuardrailsManagerStorage {
         Guardrails guardrails;
@@ -39,13 +39,11 @@ library GuardrailsLib {
         }
     }
 
-    /**
-     * @notice Checks if a price-per-share (PPS) update is compliant with the current guardrails.
-     * @param currentPps The current price-per-share.
-     * @param nextPps The proposed new price-per-share.
-     * @param _timePast The time elapsed since the last update.
-     * @return bool True if the update is compliant, false otherwise.
-     */
+    /// @notice Checks if a price-per-share (PPS) update is compliant with the current guardrails.
+    /// @param currentPps The current price-per-share.
+    /// @param nextPps The proposed new price-per-share.
+    /// @param _timePast The time elapsed since the last update.
+    /// @return bool True if the update is compliant, false otherwise.
     function isCompliant(
         uint256 currentPps,
         uint256 nextPps,
@@ -87,10 +85,8 @@ library GuardrailsLib {
         }
     }
 
-    /**
-     * @notice Updates the current policy with a new one.
-     * @param guardrails_ The new guardrails to be set.
-     */
+    /// @notice Updates the current policy with a new one.
+    /// @param guardrails_ The new guardrails to be set.
     function updateGuardrails(
         Guardrails memory guardrails_
     ) external {

--- a/src/v0.6.0/libraries/RolesLib.sol
+++ b/src/v0.6.0/libraries/RolesLib.sol
@@ -2,13 +2,7 @@
 pragma solidity 0.8.26;
 
 import {Roles} from "../Roles.sol";
-import {OnlySafe, OnlyWhitelistManager} from "../primitives/Errors.sol";
-import {
-    OnlySafe,
-    OnlySecurityCouncil,
-    OnlyValuationManagerOrSecurityCouncil,
-    OnlyWhitelistManager
-} from "../primitives/Errors.sol";
+import {OnlySafe, OnlySecurityCouncil, OnlyValuationManager, OnlyWhitelistManager} from "../primitives/Errors.sol";
 import {
     FeeReceiverUpdated,
     SafeUpdated,
@@ -44,11 +38,10 @@ library RolesLib {
         }
     }
 
-    function _onlyValuationManagerOrSecurityCouncil() internal view {
+    function _onlyValuationManager() internal view {
         address _valuationManager = _getRolesStorage().valuationManager;
-        address _securityCouncil = _getRolesStorage().securityCouncil;
-        if (_valuationManager != msg.sender && _securityCouncil != msg.sender) {
-            revert OnlyValuationManagerOrSecurityCouncil(_valuationManager, _securityCouncil);
+        if (_valuationManager != msg.sender) {
+            revert OnlyValuationManager(_valuationManager);
         }
     }
 

--- a/src/v0.6.0/primitives/Errors.sol
+++ b/src/v0.6.0/primitives/Errors.sol
@@ -80,10 +80,9 @@ error OnlySafe(address safe);
 /// @param whitelistManager The address of the whitelist manager.
 error OnlyWhitelistManager(address whitelistManager);
 
-/// @notice Indicates that the caller is not the valuation manager or the security council.
+/// @notice Indicates that the caller is not the valuation manager.
 /// @param valuationManager The address of the valuation manager.
-/// @param securityCouncil The address of the security council.
-error OnlyValuationManagerOrSecurityCouncil(address valuationManager, address securityCouncil);
+error OnlyValuationManager(address valuationManager);
 
 /// @notice Indicates that the safe upgradeability has been given up..
 error SafeUpgradeabilityNotAllowed();

--- a/src/v0.6.0/primitives/Events.sol
+++ b/src/v0.6.0/primitives/Events.sol
@@ -119,6 +119,12 @@ event FeeTaken(
     uint256 protocolShares
 );
 
+/// @notice Emitted when haircut shares are burned during synchronous redeem.
+/// @param owner The address whose shares were subject to haircut.
+/// @param shares The number of shares taken as haircut.
+/// @param rate The haircut rate applied.
+event HaircutTaken(address indexed owner, uint256 shares, uint16 rate);
+
 // ********************* ERC7540 ********************* //
 /// @notice Emitted when the totalAssets variable is updated.
 /// @param totalAssets The new total assets value.

--- a/src/v0.6.0/primitives/Struct.sol
+++ b/src/v0.6.0/primitives/Struct.sol
@@ -8,6 +8,7 @@ pragma solidity 0.8.26;
 /// @param performanceRate Performance fee rate in basis points.
 /// @param entryRate Entry fee rate in basis points.
 /// @param exitRate Exit fee rate in basis points.
+/// @param haircutRate Haircut fee rate in basis points.
 struct Rates {
     uint16 managementRate;
     uint16 performanceRate;

--- a/src/v0.6.0/vault/Vault-v0.6.0.sol
+++ b/src/v0.6.0/vault/Vault-v0.6.0.sol
@@ -128,13 +128,13 @@ contract Vault is ERC7540, Whitelistable, FeeManager, GuardrailsManager {
         _;
     }
 
-    // @notice Reverts if totalAssets is expired.
+    /// @notice Reverts if totalAssets is expired.
     modifier onlySyncDeposit() {
         VaultLib._onlySyncDeposit();
         _;
     }
 
-    // @notice Reverts if totalAssets is valid.
+    /// @notice Reverts if totalAssets is valid.
     modifier onlyAsyncDeposit() {
         VaultLib._onlyAsyncDeposit();
         _;
@@ -268,6 +268,7 @@ contract Vault is ERC7540, Whitelistable, FeeManager, GuardrailsManager {
     /// @notice Function to bundle a claim of shares and a request redeem. It can be convenient for UX.
     /// @dev if claimable == 0, it has the same behavior as requestRedeem function.
     /// @dev if claimable > 0, user shares follow this path: vault --> user ; user --> pendingSilo
+    /// @param sharesToRedeem The number of shares to redeem.
     function claimSharesAndRequestRedeem(
         uint256 sharesToRedeem
     ) public onlyOpen whenNotPaused returns (uint40 requestId) {
@@ -587,7 +588,7 @@ contract Vault is ERC7540, Whitelistable, FeeManager, GuardrailsManager {
         return assets;
     }
 
-    /// @notice Returns the maximun amount of assets a controller can use to claim shares.
+    /// @notice Returns the maximum amount of assets a controller can use to claim shares.
     /// @param  controller address to check
     /// @dev    If the contract is paused no deposit/claims are possible.
     function maxDeposit(
@@ -597,7 +598,7 @@ contract Vault is ERC7540, Whitelistable, FeeManager, GuardrailsManager {
         return claimableDepositRequest(0, controller);
     }
 
-    /// @notice Returns the maximun amount of shares a controller can get by claiming a deposit request.
+    /// @notice Returns the maximum amount of shares a controller can get by claiming a deposit request.
     /// @param controller The controller.
     /// @dev    If the contract is paused no deposit/claims are possible.
     /// @dev    We read the claimableDepositRequest of the controller then convert it to shares using the
@@ -610,7 +611,7 @@ contract Vault is ERC7540, Whitelistable, FeeManager, GuardrailsManager {
         uint40 lastDepositId = ERC7540Lib._getERC7540Storage().lastDepositRequestId[controller];
         uint256 claimable = claimableDepositRequest(lastDepositId, controller);
         uint256 shares = convertToShares(claimable, lastDepositId);
-        // the maximun amount of shares a controller can claim is the normal claimable amount minus the entry fee
+        // the maximum amount of shares a controller can claim is the normal claimable amount minus the entry fee
         shares -= FeeLib.computeFee(shares, ERC7540Lib.getSettlementEntryFeeRate(lastDepositId));
         return shares;
     }

--- a/src/v0.6.0/vault/Vault-v0.6.0.sol
+++ b/src/v0.6.0/vault/Vault-v0.6.0.sol
@@ -34,7 +34,7 @@ import {FeeRegistry} from "../../protocol-v1/FeeRegistry.sol";
 import {GuardrailsManager} from "../GuardRailsManager.sol";
 
 import {GuardrailsLib} from "../libraries/GuardrailsLib.sol";
-import {DepositSync, Referral, StateUpdated, WithdrawSync} from "../primitives/Events.sol";
+import {DepositSync, HaircutTaken, Referral, StateUpdated, WithdrawSync} from "../primitives/Events.sol";
 import {ERC4626Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -53,14 +53,14 @@ using Math for uint256;
 /// @param valuationManager The address of the valuation manager.
 /// @param admin The address of the owner of the vault.
 /// @param feeReceiver The address of the fee receiver.
-/// @param feeRegistry The address of the fee registry.
-/// @param wrappedNativeToken The address of the wrapped native token.
 /// @param managementRate The management fee rate.
 /// @param performanceRate The performance fee rate.
+/// @param accessMode The access mode (Whitelist or Blacklist).
 /// @param entryRate The entry fee rate.
 /// @param exitRate The exit fee rate.
-/// @param rateUpdateCooldown The cooldown period for updating the fee rates.
-/// @param accessMode The access mode (Whitelist or Blacklist).
+/// @param haircutRate The haircut fee rate for synchronous redeems.
+/// @param securityCouncil The address of the security council.
+/// @param externalSanctionsList The address of the external sanctions list.
 struct InitStruct {
     IERC20 underlying;
     string name;
@@ -76,6 +76,7 @@ struct InitStruct {
     // added in v0.6.0
     uint16 entryRate;
     uint16 exitRate;
+    uint16 haircutRate;
     address securityCouncil;
     address externalSanctionsList;
 }
@@ -216,7 +217,7 @@ contract Vault is ERC7540, Whitelistable, FeeManager, GuardrailsManager {
         emit Referral(referral, msg.sender, 0, assets);
     }
 
-    /// @notice Deposit in a synchronous fashion into the vault.
+    /// @notice Redeem in a synchronous fashion from the vault.
     /// @param shares The shares to redeem.
     /// @param receiver The receiver of the assets.
     /// @return assets The resulting assets.
@@ -231,7 +232,8 @@ contract Vault is ERC7540, Whitelistable, FeeManager, GuardrailsManager {
         // first we need to compute the exit fee
         uint256 exitFeeShares = FeeLib.computeFee(shares, exitRate);
 
-        uint256 haircutShares = FeeLib.computeFee(shares - exitFeeShares, FeeLib.feeRates().haircutRate);
+        uint16 haircutRate = FeeLib.feeRates().haircutRate;
+        uint256 haircutShares = FeeLib.computeFee(shares - exitFeeShares, haircutRate);
         assets = _convertToAssets(shares - haircutShares - exitFeeShares, Math.Rounding.Floor);
 
         // burn all the shares and remove the assets from the total assets
@@ -240,7 +242,9 @@ contract Vault is ERC7540, Whitelistable, FeeManager, GuardrailsManager {
 
         IERC20(asset()).safeTransferFrom(safe(), receiver, assets);
 
-        // missing haircut event !
+        if (haircutShares > 0) {
+            emit HaircutTaken(msg.sender, haircutShares, haircutRate);
+        }
 
         FeeLib.takeFees(exitFeeShares, FeeType.Exit, exitRate, 0);
 
@@ -401,17 +405,17 @@ contract Vault is ERC7540, Whitelistable, FeeManager, GuardrailsManager {
     }
 
     /// @notice Function to propose a new valuation for the vault.
-    /// @notice It can only be called by the ValueManager.
+    /// @notice It can only be called by the valuation manager.
     /// @param _newTotalAssets The new total assets of the vault.
     function updateNewTotalAssets(
         uint256 _newTotalAssets
-    ) public onlyValuationManagerOrSecurityCouncil {
+    ) public onlyValuationManager {
         if (VaultLib._getVaultStorage().state == State.Closed) {
             revert Closed();
         }
 
         // if totalAssets is not expired yet it means syncDeposit are allowed
-        // in this case we do not allow onlyValuationManager to propose a new nav
+        // in this case we do not allow the valuation manager to propose a new nav
         // he must call unvalidateTotalAssets first.
         if (isTotalAssetsValid()) {
             revert ValuationUpdateNotAllowed();
@@ -425,16 +429,29 @@ contract Vault is ERC7540, Whitelistable, FeeManager, GuardrailsManager {
 
         uint256 lastFeeTime = FeeLib._getFeeManagerStorage().lastFeeTime;
         uint256 timePastSinceLastValuationUpdate = block.timestamp - lastFeeTime;
-        // we are going to check that the new total assets respect the guardrails
-        // only if the caller is the valuation manager
-        if (
-            msg.sender == RolesLib._getRolesStorage().valuationManager && lastFeeTime != 0
-                && timePastSinceLastValuationUpdate != 0
-        ) {
+        // check that the new total assets respect the guardrails
+        if (lastFeeTime != 0 && timePastSinceLastValuationUpdate != 0) {
             if (!GuardrailsManager.isCompliant(currentPps, nextPps, timePastSinceLastValuationUpdate)) {
                 revert GuardrailsViolation();
             }
         }
+        ERC7540Lib.updateNewTotalAssets(_newTotalAssets);
+    }
+
+    /// @notice Function for the security council to update the total assets without guardrails.
+    /// @notice It can only be called by the security council.
+    /// @param _newTotalAssets The new total assets of the vault.
+    function securityCouncilUpdateTotalAssets(
+        uint256 _newTotalAssets
+    ) public onlySecurityCouncil {
+        if (VaultLib._getVaultStorage().state == State.Closed) {
+            revert Closed();
+        }
+
+        if (isTotalAssetsValid()) {
+            revert ValuationUpdateNotAllowed();
+        }
+
         ERC7540Lib.updateNewTotalAssets(_newTotalAssets);
     }
 

--- a/src/v0.6.0/vault/VaultInit.sol
+++ b/src/v0.6.0/vault/VaultInit.sol
@@ -71,7 +71,8 @@ contract VaultInit is ERC7540, Whitelistable, FeeManager, GuardrailsManager {
             _performanceRate: init.performanceRate,
             _decimals: IERC20Metadata(address(init.underlying)).decimals(),
             _entryRate: init.entryRate,
-            _exitRate: init.exitRate
+            _exitRate: init.exitRate,
+            _haircutRate: init.haircutRate
         });
         __GuardrailsManager_init(Guardrails({upperRate: type(uint256).max, lowerRate: type(int256).min + 1}));
 

--- a/test/v0.6.0/Guardrails.t.sol
+++ b/test/v0.6.0/Guardrails.t.sol
@@ -43,7 +43,7 @@ contract TestGuardrails is BaseTest {
         vault.updateNewTotalAssets(1);
     }
 
-    function test_updateNewTotalAssets_PassesIfSubmittedBySecurityCouncil() public {
+    function test_securityCouncilUpdateTotalAssets_PassesWithoutGuardrailsCheck() public {
         dealAndApproveAndWhitelist(user1.addr);
         requestDeposit(10 ** vault.underlyingDecimals(), user1.addr);
         updateAndSettle(0);
@@ -56,7 +56,7 @@ contract TestGuardrails is BaseTest {
         vault.updateGuardrails(guardrails);
 
         vm.prank(vault.securityCouncil());
-        vault.updateNewTotalAssets(1);
+        vault.securityCouncilUpdateTotalAssets(1);
     }
 
     function test_updateGuardrails_RevertsIfLowerRateIsInt256Min() public {

--- a/test/v0.6.0/Misc.t.sol
+++ b/test/v0.6.0/Misc.t.sol
@@ -234,9 +234,9 @@ contract TestMisc is BaseTest {
         assertEq(vault.totalAssetsLifespan(), 1000);
     }
 
-    function test_securityCouncilCanUpdateNewTotalAssets() public {
+    function test_securityCouncilCanUpdateTotalAssets() public {
         vm.prank(vault.securityCouncil());
-        vault.updateNewTotalAssets(1);
+        vault.securityCouncilUpdateTotalAssets(1);
 
         assertEq(vault.newTotalAssets(), 1);
     }

--- a/test/v0.6.0/SafeAsOperator.t.sol
+++ b/test/v0.6.0/SafeAsOperator.t.sol
@@ -90,8 +90,15 @@ contract TestSafeAsOperator is BaseTest {
 
         _callAllFunctionsExpectSuccess(user2.addr, user2.addr);
 
-        // Note: safe cannot call requestDeposit for users - onlyOperator excludes safe
-        // Only deposit/mint/redeem/withdraw use onlyOperatorOrSafe which allows safe
+        address operator = safe.addr;
+        address controller = user2.addr;
+        vm.prank(operator);
+        vm.expectRevert(ERC7540InvalidOperator.selector);
+        vault.requestDeposit(100, controller, controller);
+
+        vm.prank(operator);
+        vm.expectRevert(ERC7540InvalidOperator.selector);
+        vault.requestDeposit(100, controller, controller, controller);
     }
 
     // since onlyOperator is called at the begining we can bulk test all functions that should revert
@@ -151,4 +158,3 @@ contract TestSafeAsOperator is BaseTest {
         vault.mint(1, controller, controller);
     }
 }
-

--- a/test/v0.6.0/SetUp.sol
+++ b/test/v0.6.0/SetUp.sol
@@ -125,6 +125,7 @@ contract SetUp is Test {
             accessMode: enableWhitelist ? AccessMode.Whitelist : AccessMode.Blacklist,
             entryRate: _entryRate,
             exitRate: _exitRate,
+            haircutRate: 0,
             securityCouncil: admin.addr,
             externalSanctionsList: address(0)
         });

--- a/test/v0.6.0/Settle.t.sol
+++ b/test/v0.6.0/Settle.t.sol
@@ -270,12 +270,8 @@ contract TestSettle is BaseTest {
         vault.settleRedeem(1);
     }
 
-    function test_updateNewTotalAssets_revertIfNotTotalAssetsManager() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                OnlyValuationManagerOrSecurityCouncil.selector, vault.valuationManager(), vault.securityCouncil()
-            )
-        );
+    function test_updateNewTotalAssets_revertIfNotValuationManager() public {
+        vm.expectRevert(abi.encodeWithSelector(OnlyValuationManager.selector, vault.valuationManager()));
         vault.updateNewTotalAssets(0);
     }
 


### PR DESCRIPTION
- Revert v0.5.0 files to main branch state
- Add separate security council entry point (securityCouncilUpdateTotalAssets)
- Add haircutRate validation in FeeLib.updateRates()
- Add haircutRate to InitStruct and FeeManager init
- Add HaircutTaken event emission in syncRedeem
- Fix duplicate imports in RolesLib.sol
- Fix natspecs (syncRedeem, Whitelistable, Roles)
- Import InitStruct in protocol-v3 factory instead of redeclaring
- Reorder FeeLib constants (MAX_HAIRCUT_RATE after MAX_PROTOCOL_RATE)
- Update tests for new security council function