### PR TITLE
feat: add high water mark reset capability

### DIFF
--- a/src/v0.6.0/FeeManager.sol
+++ b/src/v0.6.0/FeeManager.sol
@@ -28,6 +28,7 @@ abstract contract FeeManager is Ownable2StepUpgradeable {
     /// @param rates the current fee rates
     /// @param oldRates the previous fee rates, they are used during the cooldown period when new rates are set
     /// @param feeRegistry the fee registry contract, it is used to read the protocol rate
+    /// @param allowHighWaterMarkReset whether the safe can reset the high water mark to current price per share
     struct FeeManagerStorage {
         FeeRegistry feeRegistry;
         uint256 newRatesTimestamp;
@@ -35,13 +36,14 @@ abstract contract FeeManager is Ownable2StepUpgradeable {
         uint256 highWaterMark;
         // Deprecated in v0.6.0
         uint256 cooldown;
-        // v0.6.0 upgrade edit the Rates struct it is fine because both rates and oldRates
+        // v0.6.0 upgrade edit the Rates struct. It is fine because both rates and oldRates
         // are not stored in the same slot as stated in the documentation
         // https://docs.soliditylang.org/en/v0.8.33/internals/layout_in_storage.html#layout-of-state-variables-in-storage-and-transient-storage
         // "Structs and array data always start a new slot and their items are packed tightly according to these rules."
         Rates rates;
         // Deprecated in v0.6.0
         Rates oldRates;
+        bool allowHighWaterMarkReset;
     }
 
     /// @notice Initialize the FeeManager contract
@@ -52,6 +54,7 @@ abstract contract FeeManager is Ownable2StepUpgradeable {
     /// @param _entryRate the entry fee rate, expressed in BPS
     /// @param _exitRate the exit fee rate, expressed in BPS
     /// @param _haircutRate the haircut fee rate, expressed in BPS
+    /// @param _allowHighWaterMarkReset whether the safe can reset the high water mark to current price per share
     // solhint-disable-next-line func-name-mixedcase
     function __FeeManager_init(
         address _registry,
@@ -60,7 +63,8 @@ abstract contract FeeManager is Ownable2StepUpgradeable {
         uint256 _decimals,
         uint16 _entryRate,
         uint16 _exitRate,
-        uint16 _haircutRate
+        uint16 _haircutRate,
+        bool _allowHighWaterMarkReset
     ) internal onlyInitializing {
         FeeManagerStorage storage $ = FeeLib._getFeeManagerStorage();
         FeeLib.updateRates(
@@ -77,6 +81,7 @@ abstract contract FeeManager is Ownable2StepUpgradeable {
         $.feeRegistry = FeeRegistry(_registry);
         $.highWaterMark = 10 ** _decimals;
         $.lastFeeTime = block.timestamp;
+        $.allowHighWaterMarkReset = _allowHighWaterMarkReset;
     }
 
     /// @notice update the fee rates, applied immediately

--- a/src/v0.6.0/libraries/FeeLib.sol
+++ b/src/v0.6.0/libraries/FeeLib.sol
@@ -6,7 +6,7 @@ import {FeeManager} from "../FeeManager.sol";
 import {Roles} from "../Roles.sol";
 import {ERC7540Lib} from "../libraries/ERC7540Lib.sol";
 import {FeeType} from "../primitives/Enums.sol";
-import {AboveMaxRate} from "../primitives/Errors.sol";
+import {AboveMaxRate, HighWaterMarkResetNotAllowed, OnlySafe} from "../primitives/Errors.sol";
 import {FeeTaken, HighWaterMarkUpdated, RatesUpdated} from "../primitives/Events.sol";
 import {RatesUpdated} from "../primitives/Events.sol";
 import {Rates} from "../primitives/Struct.sol";
@@ -120,6 +120,26 @@ library FeeLib {
             emit HighWaterMarkUpdated(_highWaterMark, _newHighWaterMark);
             $.highWaterMark = _newHighWaterMark;
         }
+    }
+
+    /// @dev Reset the high water mark to the current price per share
+    /// @dev Can only be called by the safe and only if allowHighWaterMarkReset was set to true at initialization
+    function resetHighWaterMark() public {
+        FeeManager.FeeManagerStorage storage $ = _getFeeManagerStorage();
+
+        // Check if reset is allowed
+        if (!$.allowHighWaterMarkReset) {
+            revert HighWaterMarkResetNotAllowed();
+        }
+
+        // Get current price per share
+        uint256 _decimals = ERC7540(address(this)).decimals();
+        uint256 currentPricePerShare = ERC7540(address(this)).convertToAssets(10 ** _decimals);
+
+        // Reset high water mark to current price per share
+        uint256 _highWaterMark = $.highWaterMark;
+        emit HighWaterMarkUpdated(_highWaterMark, currentPricePerShare);
+        $.highWaterMark = currentPricePerShare;
     }
 
     /// @notice Take the fees by minting the manager and protocol shares

--- a/src/v0.6.0/primitives/Errors.sol
+++ b/src/v0.6.0/primitives/Errors.sol
@@ -76,6 +76,9 @@ error SyncRedeemNotAllowed();
 /// @param maxRate The maximum allowable rate.
 error AboveMaxRate(uint256 maxRate);
 
+/// @notice Indicates that high water mark reset is not allowed for this vault.
+error HighWaterMarkResetNotAllowed();
+
 // ********************* ROLES ********************* //
 
 /// @notice Indicates that the caller is not a safe address.

--- a/src/v0.6.0/vault/Vault-v0.6.0.sol
+++ b/src/v0.6.0/vault/Vault-v0.6.0.sol
@@ -64,6 +64,7 @@ using Math for uint256;
 /// @param securityCouncil The address of the security council.
 /// @param externalSanctionsList The address of the external sanctions list.
 /// @param initialTotalAssets The initial total assets of the vault. It is used to ease vault migrations.
+/// @param allowHighWaterMarkReset Whether the safe can reset the high water mark to current price per share.
 struct InitStruct {
     IERC20 underlying;
     string name;
@@ -84,6 +85,7 @@ struct InitStruct {
     address externalSanctionsList;
     uint256 initialTotalAssets;
     address superOperator;
+    bool allowHighWaterMarkReset;
 }
 
 /// @custom:oz-upgrades-from src/v0.5.0/Vault.sol:Vault
@@ -570,6 +572,12 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
 
     function expireTotalAssets() public onlySafe {
         ERC7540Lib._getERC7540Storage().totalAssetsExpiration = 0;
+    }
+
+    /// @notice Resets the high water mark to the current price per share.
+    /// @dev Can only be called by the safe and only if allowHighWaterMarkReset was set to true at initialization.
+    function resetHighWaterMark() external onlySafe {
+        FeeLib.resetHighWaterMark();
     }
 
     ////////////////////////////////

--- a/src/v0.6.0/vault/VaultInit.sol
+++ b/src/v0.6.0/vault/VaultInit.sol
@@ -78,7 +78,8 @@ contract VaultInit is ERC7540, Accessable, FeeManager, GuardrailsManager {
             _decimals: IERC20Metadata(address(init.underlying)).decimals(),
             _entryRate: init.entryRate,
             _exitRate: init.exitRate,
-            _haircutRate: init.haircutRate
+            _haircutRate: init.haircutRate,
+            _allowHighWaterMarkReset: init.allowHighWaterMarkReset
         });
 
         emit StateUpdated(State.Open);

--- a/test/v0.6.0/FeeManager.t.sol
+++ b/test/v0.6.0/FeeManager.t.sol
@@ -8,6 +8,8 @@ import {BaseTest} from "./Base.sol";
 import {IERC20Metadata, IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {AccessMode} from "@src/v0.6.0/primitives/Enums.sol";
+import {HighWaterMarkResetNotAllowed, OnlySafe} from "@src/v0.6.0/primitives/Errors.sol";
+import {HighWaterMarkUpdated} from "@src/v0.6.0/primitives/Events.sol";
 import {InitStruct} from "@src/v0.6.0/vault/Vault-v0.6.0.sol";
 
 contract TestFeeManager is BaseTest {
@@ -92,7 +94,8 @@ contract TestFeeManager is BaseTest {
             securityCouncil: admin.addr,
             externalSanctionsList: address(0),
             initialTotalAssets: initialAssets,
-            superOperator: superOperator.addr
+            superOperator: superOperator.addr,
+            allowHighWaterMarkReset: false
         });
 
         VaultHelper newVault = new VaultHelper(false);
@@ -800,5 +803,199 @@ contract TestFeeManager is BaseTest {
         vm.prank(vault.safe());
         vm.expectRevert(abi.encodeWithSelector(NewTotalAssetsMissing.selector));
         vault.close(1);
+    }
+
+    // ********************* HIGH WATER MARK RESET TESTS ********************* //
+
+    function test_resetHighWaterMark_whenFlagEnabled_resetsToCurrentPricePerShare() public {
+        // Deploy a new vault with allowHighWaterMarkReset enabled
+        InitStruct memory initStruct = InitStruct({
+            underlying: underlying,
+            name: vaultName,
+            symbol: vaultSymbol,
+            safe: safe.addr,
+            whitelistManager: whitelistManager.addr,
+            valuationManager: valuationManager.addr,
+            admin: admin.addr,
+            feeReceiver: feeReceiver.addr,
+            managementRate: managementFee,
+            performanceRate: performanceFee,
+            accessMode: AccessMode.Blacklist,
+            entryRate: entryFee,
+            exitRate: exitFee,
+            haircutRate: 0,
+            securityCouncil: admin.addr,
+            externalSanctionsList: address(0),
+            initialTotalAssets: 0,
+            superOperator: superOperator.addr,
+            allowHighWaterMarkReset: true
+        });
+
+        VaultHelper newVault = new VaultHelper(false);
+        newVault.initialize(abi.encode(initStruct), address(protocolRegistry), WRAPPED_NATIVE_TOKEN);
+        vault = newVault;
+
+        // Make some deposits and settlements to increase the high water mark
+        // First, deal assets and approve
+        uint256 depositAmount = _10K;
+        dealAmountAndApprove(user1.addr, depositAmount);
+
+        // Request deposit
+        vm.prank(user1.addr);
+        newVault.requestDeposit(depositAmount, user1.addr, user1.addr);
+
+        // Update total assets and settle (use a higher value to create performance)
+        uint256 newTotalAssets = _20M;
+        vm.prank(newVault.valuationManager());
+        newVault.updateNewTotalAssets(newTotalAssets);
+        vm.warp(block.timestamp + 1 days);
+        vm.prank(newVault.safe());
+        newVault.settleDeposit(newTotalAssets);
+
+        uint256 hwmBefore = newVault.highWaterMark();
+        uint256 currentPps = newVault.convertToAssets(10 ** newVault.decimals());
+
+        vm.prank(newVault.valuationManager());
+        newVault.updateNewTotalAssets(newTotalAssets / 2);
+        vm.warp(block.timestamp + 1 days);
+        vm.prank(newVault.safe());
+        newVault.settleDeposit(newTotalAssets / 2);
+
+        assertNotEq(newVault.highWaterMark(), newVault.pricePerShare(), "hwm should not be equal to pps");
+
+        // Reset the high water mark
+        vm.prank(newVault.safe());
+        newVault.resetHighWaterMark();
+
+        // High water mark should now equal current price per share
+        assertEq(newVault.highWaterMark(), newVault.pricePerShare(), "HWM should equal current PPS after reset");
+    }
+
+    function test_resetHighWaterMark_whenFlagDisabled_reverts() public {
+        // Default vault has allowHighWaterMarkReset: false
+        uint256 hwmBefore = vault.highWaterMark();
+
+        // Attempt to reset should revert
+        vm.prank(vault.safe());
+        vm.expectRevert(HighWaterMarkResetNotAllowed.selector);
+        vault.resetHighWaterMark();
+
+        // High water mark should remain unchanged
+        assertEq(vault.highWaterMark(), hwmBefore, "HWM should remain unchanged");
+    }
+
+    function test_resetHighWaterMark_whenNotCalledBySafe_reverts() public {
+        // Attempt to reset from non-safe address should revert
+        vm.prank(admin.addr);
+        vm.expectRevert(abi.encodeWithSelector(OnlySafe.selector, safe.addr));
+        vault.resetHighWaterMark();
+
+        vm.prank(user1.addr);
+        vm.expectRevert(abi.encodeWithSelector(OnlySafe.selector, safe.addr));
+        vault.resetHighWaterMark();
+
+        vm.prank(valuationManager.addr);
+        vm.expectRevert(abi.encodeWithSelector(OnlySafe.selector, safe.addr));
+        vault.resetHighWaterMark();
+    }
+
+    function test_resetHighWaterMark_emitsHighWaterMarkUpdatedEvent() public {
+        // Deploy a new vault with allowHighWaterMarkReset enabled
+        InitStruct memory initStruct = InitStruct({
+            underlying: underlying,
+            name: vaultName,
+            symbol: vaultSymbol,
+            safe: safe.addr,
+            whitelistManager: whitelistManager.addr,
+            valuationManager: valuationManager.addr,
+            admin: admin.addr,
+            feeReceiver: feeReceiver.addr,
+            managementRate: managementFee,
+            performanceRate: performanceFee,
+            accessMode: AccessMode.Blacklist,
+            entryRate: entryFee,
+            exitRate: exitFee,
+            haircutRate: 0,
+            securityCouncil: admin.addr,
+            externalSanctionsList: address(0),
+            initialTotalAssets: 0,
+            superOperator: superOperator.addr,
+            allowHighWaterMarkReset: true
+        });
+
+        VaultHelper newVault = new VaultHelper(false);
+        newVault.initialize(abi.encode(initStruct), address(protocolRegistry), WRAPPED_NATIVE_TOKEN);
+        vault = newVault;
+
+        // Make some deposits and settlements to increase the high water mark
+        // First, deal assets and approve
+        uint256 depositAmount = _10K;
+        dealAmountAndApprove(user1.addr, depositAmount);
+
+        // Request deposit
+        vm.prank(user1.addr);
+        newVault.requestDeposit(depositAmount, user1.addr, user1.addr);
+
+        // Update total assets and settle (use a higher value to create performance)
+        uint256 newTotalAssets = _20M;
+        vm.prank(newVault.valuationManager());
+        newVault.updateNewTotalAssets(newTotalAssets);
+        vm.warp(block.timestamp + 1 days);
+        vm.prank(newVault.safe());
+        newVault.settleDeposit(newTotalAssets);
+
+        uint256 hwmBefore = newVault.highWaterMark();
+        uint256 currentPps = newVault.convertToAssets(10 ** newVault.decimals());
+
+        // Expect the HighWaterMarkUpdated event
+        vm.expectEmit(true, true, true, true);
+        emit HighWaterMarkUpdated(hwmBefore, currentPps);
+
+        // Reset the high water mark
+        vm.prank(newVault.safe());
+        newVault.resetHighWaterMark();
+    }
+
+    function test_resetHighWaterMark_whenPricePerShareEqualsHighWaterMark_stillResets() public {
+        // Deploy a new vault with allowHighWaterMarkReset enabled
+        InitStruct memory initStruct = InitStruct({
+            underlying: underlying,
+            name: vaultName,
+            symbol: vaultSymbol,
+            safe: safe.addr,
+            whitelistManager: whitelistManager.addr,
+            valuationManager: valuationManager.addr,
+            admin: admin.addr,
+            feeReceiver: feeReceiver.addr,
+            managementRate: 0, // No fees to keep it simple
+            performanceRate: 0,
+            accessMode: AccessMode.Blacklist,
+            entryRate: 0,
+            exitRate: 0,
+            haircutRate: 0,
+            securityCouncil: admin.addr,
+            externalSanctionsList: address(0),
+            initialTotalAssets: 0,
+            superOperator: superOperator.addr,
+            allowHighWaterMarkReset: true
+        });
+
+        VaultHelper newVault = new VaultHelper(false);
+        newVault.initialize(abi.encode(initStruct), address(protocolRegistry), WRAPPED_NATIVE_TOKEN);
+
+        uint256 hwmBefore = newVault.highWaterMark();
+        uint256 currentPps = newVault.convertToAssets(10 ** newVault.decimals());
+
+        // Initially, HWM should equal current PPS
+        assertEq(hwmBefore, currentPps, "HWM should equal current PPS initially");
+
+        // Reset should still work even when they're equal
+        vm.prank(newVault.safe());
+        newVault.resetHighWaterMark();
+
+        // HWM should still equal current PPS
+        uint256 hwmAfter = newVault.highWaterMark();
+        assertEq(hwmAfter, currentPps, "HWM should still equal current PPS after reset");
+        assertEq(hwmAfter, hwmBefore, "HWM should remain the same when already equal to PPS");
     }
 }

--- a/test/v0.6.0/PreMint.t.sol
+++ b/test/v0.6.0/PreMint.t.sol
@@ -32,7 +32,8 @@ contract TestPreMint is BaseTest {
             securityCouncil: admin.addr,
             externalSanctionsList: address(0),
             initialTotalAssets: 0,
-            superOperator: superOperator.addr
+            superOperator: superOperator.addr,
+            allowHighWaterMarkReset: false
         });
 
         VaultHelper newVault = new VaultHelper(false);
@@ -67,7 +68,8 @@ contract TestPreMint is BaseTest {
             securityCouncil: admin.addr,
             externalSanctionsList: address(0),
             initialTotalAssets: initialAssets,
-            superOperator: superOperator.addr
+            superOperator: superOperator.addr,
+            allowHighWaterMarkReset: false
         });
 
         VaultHelper newVault = new VaultHelper(false);
@@ -108,7 +110,8 @@ contract TestPreMint is BaseTest {
             securityCouncil: admin.addr,
             externalSanctionsList: address(0),
             initialTotalAssets: initialAssets,
-            superOperator: superOperator.addr
+            superOperator: superOperator.addr,
+            allowHighWaterMarkReset: false
         });
 
         VaultHelper newVault = new VaultHelper(false);

--- a/test/v0.6.0/SetUp.sol
+++ b/test/v0.6.0/SetUp.sol
@@ -130,7 +130,8 @@ contract SetUp is Test {
             securityCouncil: admin.addr,
             externalSanctionsList: address(0),
             initialTotalAssets: 0,
-            superOperator: superOperator.addr
+            superOperator: superOperator.addr,
+            allowHighWaterMarkReset: false
         });
         // if proxy is true, we use the factory to create the vault proxy
         if (proxy) {


### PR DESCRIPTION
Allow safe to reset high water mark to current price per share, but only if explicitly enabled at vault initialization via allowHighWaterMarkReset parameter. Once set at init, the flag cannot be changed.

- Add allowHighWaterMarkReset to InitStruct and FeeManagerStorage
- Implement resetHighWaterMark() with flag and safe checks
- Add comprehensive tests for all scenarios