### PR TITLE
fix: address audit findings for v0.6.0

### DIFF
--- a/script/deploy_vault_v060_sdk_test.s.sol
+++ b/script/deploy_vault_v060_sdk_test.s.sol
@@ -117,7 +117,6 @@ contract DeployVaultV060SdkTest is Script {
         // ────────────────────────────
         vault.updateMaxCap(MAX_CAP);
         vault.updateTotalAssetsLifespan(TOTAL_ASSETS_LIFESPAN);
-        vault.setIsSyncRedeemAllowed(true);
 
         // ── 7. WhitelistManager: whitelist role addresses
         // ─────────────────────

--- a/specs/CancelRequestRedeem-spec.md
+++ b/specs/CancelRequestRedeem-spec.md
@@ -1,0 +1,41 @@
+## `cancelRequestRedeem` Specification
+
+### Purpose
+Allows cancellation of a pending redeem request, returning shares from the `pendingSilo` back to the controller before settlement occurs.
+
+### Function Signature
+```solidity
+function cancelRequestRedeem(address controller) external
+```
+
+### Access Control
+- **Modifier:** `onlyOperatorOrSuperOperator(controller)`
+  - The controller themselves can cancel (`msg.sender == controller`)
+  - A registered operator of the controller can cancel
+  - The superOperator can cancel on behalf of any user **except** the `protocolFeeReceiver`
+- **Pause protection:** Implicit via `ERC20._transfer` in the share transfer (reverts with `EnforcedPause`)
+- **No whitelist/blacklist check:** Blacklisted users can cancel their pending redeem requests
+
+### Preconditions
+- The controller must have a pending redeem request in the **current epoch** (`lastRedeemRequestId[controller] == redeemEpochId`)
+- `updateNewTotalAssets` must **not** have been called since the request was made (which would have advanced the epoch)
+
+### Behavior
+1. Reads the controller's `lastRedeemRequestId` and verifies it matches the current `redeemEpochId`
+2. Reads the pending share amount from `epochs[requestId].redeemRequest[controller]`
+3. Zeros out the request: `epochs[requestId].redeemRequest[controller] = 0`
+4. Transfers shares back from `pendingSilo` to `controller` via `transmitFrom` (uses `ERC20._transfer` internally to bypass approval and access-control hooks)
+5. Emits `RedeemRequestCanceled(requestId, controller, requestedAmount)`
+
+### Reverts
+| Condition | Error |
+|-----------|-------|
+| Caller is not controller, operator, or superOperator | `ERC7540InvalidOperator` |
+| SuperOperator acting on `protocolFeeReceiver` | `ERC7540InvalidOperator` |
+| Request epoch doesn't match current epoch (already settled, never requested, or NAV updated) | `RequestNotCancelable(requestId)` |
+| Vault is paused | `EnforcedPause` |
+
+### Event
+```solidity
+event RedeemRequestCanceled(uint256 indexed requestId, address indexed controller, uint256 requestedAmount)
+```

--- a/specs/Lagoon-v0.6.0-specs.md
+++ b/specs/Lagoon-v0.6.0-specs.md
@@ -76,6 +76,8 @@
 
 - **General description:** The name, symbol and Safe can be updated by the owner.
 
+
+
 ## General considerations about the code
 
 - We had to move a lot of the existing code from contracts to libraries to reduce bytecode size. For the same reason, we have move the initialisation function outside of the vault into a separate contract, vaultInit, deployed at construction and delegate called by the vault in its initialize function.

--- a/src/v0.6.0/ERC7540.sol
+++ b/src/v0.6.0/ERC7540.sol
@@ -398,6 +398,15 @@ abstract contract ERC7540 is IERC7540Redeem, IERC7540Deposit, ERC20PausableUpgra
         ERC7540Lib.cancelRequestDeposit(controller);
     }
 
+    /// @dev Unusable when paused. Protected by ERC20PausableUpgradeable's _update function.
+    /// @notice Cancel a redeem request on behalf of a controller.
+    /// @param controller The controller, who owns the redeem request.
+    function cancelRequestRedeem(
+        address controller
+    ) external onlyOperatorOrSuperOperator(controller) {
+        ERC7540Lib.cancelRequestRedeem(controller);
+    }
+
     ///////////////////////////////
     // ## EIP7540 REDEEM FLOW ## //
     ///////////////////////////////
@@ -502,6 +511,22 @@ abstract contract ERC7540 is IERC7540Redeem, IERC7540Deposit, ERC20PausableUpgra
         // only the vault can burn shares
         require(msg.sender == address(this));
         _burn(from, shares);
+    }
+
+    /// @notice Transfers shares without any checks. This function is used to allow a transfer shares from a library
+    /// function.
+    /// @param from The address from which the shares will be transferred.
+    /// @param to The address to which the shares will be transferred.
+    /// @param value The amount of shares to transfer.
+    function transmitFrom(
+        address from,
+        address to,
+        uint256 value
+    ) external returns (bool) {
+        // only the vault can burn shares
+        require(msg.sender == address(this));
+        ERC20Upgradeable._transfer(from, to, value);
+        return true;
     }
 
     function _updateMaxCap(

--- a/src/v0.6.0/ERC7540.sol
+++ b/src/v0.6.0/ERC7540.sol
@@ -8,6 +8,8 @@ import {IWETH9} from "./interfaces/IWETH9.sol";
 import {AccessableLib} from "./libraries/AccessableLib.sol";
 import {ERC7540Lib} from "./libraries/ERC7540Lib.sol";
 import {RolesLib} from "./libraries/RolesLib.sol";
+import {VaultLib} from "./libraries/VaultLib.sol";
+import {SyncMode} from "./primitives/Enums.sol";
 import {
     AddressNotAllowed,
     ERC7540PreviewDepositDisabled,
@@ -16,9 +18,9 @@ import {
     ERC7540PreviewWithdrawDisabled,
     InvalidController,
     OnlyOneRequestAllowed,
-    SyncRedeemNotAllowed
+    SyncOperationNotAllowed
 } from "./primitives/Errors.sol";
-import {DepositSync, MaxCapUpdated, PreMint} from "./primitives/Events.sol";
+import {DepositSync, MaxCapUpdated, PreMint, SyncModeUpdated} from "./primitives/Events.sol";
 import {EpochData, SettleData} from "./primitives/Struct.sol";
 import {
     ERC20Upgradeable,
@@ -78,8 +80,7 @@ abstract contract ERC7540 is IERC7540Redeem, IERC7540Deposit, ERC20PausableUpgra
         uint128 totalAssetsLifespan;
         // New variables introduce with v0.6.0
         uint256 maxCap;
-        bool isSyncRedeemAllowed;
-        // New variables introduce with v0.6.0 (async-only mode)
+        SyncMode syncMode;
         // When true, the vault permanently forbids synchronous deposits by keeping totalAssets invalid.
         bool isAsyncOnly;
     }
@@ -119,6 +120,8 @@ abstract contract ERC7540 is IERC7540Redeem, IERC7540Deposit, ERC20PausableUpgra
             _preMint(initialTotalAssets, _safe);
         }
         _updateMaxCap(type(uint256).max);
+        // syncMode defaults to SyncMode.Both (enum value 0)
+        emit SyncModeUpdated(SyncMode.Both, SyncMode.Both);
     }
 
     /// @notice Pre-mints shares to the receiver based on the provided assets amount.
@@ -161,12 +164,6 @@ abstract contract ERC7540 is IERC7540Redeem, IERC7540Deposit, ERC20PausableUpgra
         address controller
     ) {
         ERC7540Lib._onlyOperator(controller);
-        _;
-    }
-
-    /// @notice Make sure sync redeem is allowed.
-    modifier onlySyncRedeemAllowed() {
-        if (!ERC7540Lib._getERC7540Storage().isSyncRedeemAllowed) revert SyncRedeemNotAllowed();
         _;
     }
 

--- a/src/v0.6.0/Roles.sol
+++ b/src/v0.6.0/Roles.sol
@@ -19,6 +19,7 @@ abstract contract Roles is Ownable2StepUpgradeable {
     /// @param securityCouncil The address of the security council that can update total assets without guardrails.
     /// @dev owner The address of the owner of the contract. It considered as the admin. It is not visible in the
     /// struct. It can change the others roles and itself. Initiate the fund closing. Disable the whitelist.
+    /// @custom:storage-location erc7201:hopper.storage.Roles
     struct RolesStorage {
         address whitelistManager;
         address feeReceiver;

--- a/src/v0.6.0/libraries/ERC7540Lib.sol
+++ b/src/v0.6.0/libraries/ERC7540Lib.sol
@@ -7,13 +7,12 @@ import {RolesLib} from "../Roles.sol";
 import {IERC7540Deposit} from "../interfaces/IERC7540Deposit.sol";
 import {VaultLib} from "./VaultLib.sol";
 
-import {FeeType, State} from "../primitives/Enums.sol";
+import {FeeType, State, SyncMode} from "../primitives/Enums.sol";
 import {
     AddressNotAllowed,
     AsyncOnly,
     CantDepositNativeToken,
     ERC7540InvalidOperator,
-    EnableSyncRedeemNotAllowed,
     MaxCapReached,
     NewTotalAssetsMissing,
     OnlyOneRequestAllowed,
@@ -28,8 +27,7 @@ import {
     Referral,
     SettleDeposit,
     SettleRedeem,
-    SyncOperationsDisabled,
-    SyncRedeemAllowedSwitched,
+    SyncModeUpdated,
     TotalAssetsExpirationUpdated,
     TotalAssetsLifespanUpdated,
     TotalAssetsUpdated
@@ -180,7 +178,7 @@ library ERC7540Lib {
 
     /// @notice Permanently disables synchronous behavior for the vault.
     /// @dev This sets the vault in async-only mode by making totalAssets permanently invalid.
-    ///      It also disables sync redeem.
+    ///      It also sets sync mode to None.
     ///      It resets both totalAssetsExpiration and totalAssetsLifespan to zero.
     ///      This mode is irreversible.
     function setAsyncOnly() public {
@@ -190,40 +188,28 @@ library ERC7540Lib {
         uint128 oldExpiration = $.totalAssetsExpiration;
         $.totalAssetsExpiration = 0;
         $.totalAssetsLifespan = 0;
-        $.isSyncRedeemAllowed = false;
+        SyncMode oldMode = $.syncMode;
+        $.syncMode = SyncMode.None;
 
         emit TotalAssetsExpirationUpdated(oldExpiration, 0);
+        emit SyncModeUpdated(oldMode, SyncMode.None);
         emit AsyncOnlyActivated();
     }
 
-    /// @notice Enables or disables synchronous redeem.
-    /// @param _isAllowed Whether to enable or disable synchronous redeem.
-    /// @dev In async-only this function will revert to avoid switching to sync redeem mode on.
-    ///      It will also revert if newTotalAssets.
-    function setIsSyncRedeemAllowed(
-        bool _isAllowed
+    /// @notice Updates the sync mode for the vault.
+    /// @param _mode The new sync mode.
+    /// @dev Reverts if the vault is in async-only mode.
+    function setSyncMode(
+        SyncMode _mode
     ) public {
         ERC7540.ERC7540Storage storage $ = _getERC7540Storage();
 
         if ($.isAsyncOnly) revert AsyncOnly();
-        if ($.newTotalAssets != type(uint256).max && _isAllowed) revert EnableSyncRedeemNotAllowed();
 
-        $.isSyncRedeemAllowed = _isAllowed;
+        SyncMode oldMode = $.syncMode;
+        $.syncMode = _mode;
 
-        emit SyncRedeemAllowedSwitched(_isAllowed);
-    }
-
-    function disableSyncOperations() public {
-        ERC7540.ERC7540Storage storage $ = ERC7540Lib._getERC7540Storage();
-
-        if ($.isSyncRedeemAllowed) {
-            $.isSyncRedeemAllowed = false;
-            emit SyncRedeemAllowedSwitched(false);
-        }
-        uint128 oldExpiration = $.totalAssetsExpiration;
-        $.totalAssetsExpiration = 0;
-        emit TotalAssetsExpirationUpdated(oldExpiration, 0);
-        emit SyncOperationsDisabled();
+        emit SyncModeUpdated(oldMode, _mode);
     }
 
     function decimalsOffset() internal view returns (uint8) {
@@ -712,7 +698,13 @@ library ERC7540Lib {
     }
 
     function isSyncRedeemAllowed() public view returns (bool) {
-        return _getERC7540Storage().isSyncRedeemAllowed;
+        SyncMode mode = _getERC7540Storage().syncMode;
+        return mode == SyncMode.SyncRedeem || mode == SyncMode.Both;
+    }
+
+    function isSyncDepositAllowed() public view returns (bool) {
+        SyncMode mode = _getERC7540Storage().syncMode;
+        return mode == SyncMode.SyncDeposit || mode == SyncMode.Both;
     }
 
     function supportsInterface(

--- a/src/v0.6.0/libraries/ERC7540Lib.sol
+++ b/src/v0.6.0/libraries/ERC7540Lib.sol
@@ -25,6 +25,7 @@ import {
     AsyncOnlyActivated,
     DepositRequestCanceled,
     NewTotalAssetsUpdated,
+    RedeemRequestCanceled,
     Referral,
     SettleDeposit,
     SettleRedeem,
@@ -500,6 +501,26 @@ library ERC7540Lib {
         IERC20(asset()).safeTransferFrom(address($.pendingSilo), controller, requestedAmount);
 
         emit DepositRequestCanceled(requestId, controller);
+    }
+
+    /// @dev Unusable when paused. Protected by whenNotPaused.
+    /// @notice Cancel a redeem request.
+    /// @dev It can only be called in the same epoch.
+    function cancelRequestRedeem(
+        address controller
+    ) public {
+        ERC7540.ERC7540Storage storage $ = _getERC7540Storage();
+
+        uint40 requestId = $.lastRedeemRequestId[controller];
+        if (requestId != $.redeemEpochId) {
+            revert RequestNotCancelable(requestId);
+        }
+
+        uint256 requestedAmount = $.epochs[requestId].redeemRequest[controller];
+        $.epochs[requestId].redeemRequest[controller] = 0;
+        ERC7540(address(this)).transmitFrom(address($.pendingSilo), controller, requestedAmount);
+
+        emit RedeemRequestCanceled(requestId, controller, requestedAmount);
     }
 
     ///////////////////////////////

--- a/src/v0.6.0/libraries/ERC7540Lib.sol
+++ b/src/v0.6.0/libraries/ERC7540Lib.sol
@@ -28,7 +28,10 @@ import {
     Referral,
     SettleDeposit,
     SettleRedeem,
+    SyncOperationsDisabled,
     SyncRedeemAllowedSwitched,
+    TotalAssetsExpirationUpdated,
+    TotalAssetsExpired,
     TotalAssetsLifespanUpdated,
     TotalAssetsUpdated
 } from "../primitives/Events.sol";
@@ -123,7 +126,10 @@ library ERC7540Lib {
 
         // If the vault has been set to async-only, we never make totalAssets valid again.
         if (!$.isAsyncOnly) {
-            $.totalAssetsExpiration = uint128(block.timestamp) + $.totalAssetsLifespan;
+            uint128 oldExpiration = $.totalAssetsExpiration;
+            uint128 newExpiration = uint128(block.timestamp) + $.totalAssetsLifespan;
+            $.totalAssetsExpiration = newExpiration;
+            emit TotalAssetsExpirationUpdated(oldExpiration, newExpiration);
         }
         emit TotalAssetsUpdated(newTotalAssets);
     }
@@ -182,10 +188,13 @@ library ERC7540Lib {
         ERC7540.ERC7540Storage storage $ = _getERC7540Storage();
 
         $.isAsyncOnly = true;
+        uint128 oldExpiration = $.totalAssetsExpiration;
         $.totalAssetsExpiration = 0;
         $.totalAssetsLifespan = 0;
         $.isSyncRedeemAllowed = false;
 
+        emit TotalAssetsExpirationUpdated(oldExpiration, 0);
+        emit TotalAssetsExpired();
         emit AsyncOnlyActivated();
     }
 
@@ -213,7 +222,11 @@ library ERC7540Lib {
             $.isSyncRedeemAllowed = false;
             emit SyncRedeemAllowedSwitched(false);
         }
+        uint128 oldExpiration = $.totalAssetsExpiration;
         $.totalAssetsExpiration = 0;
+        emit TotalAssetsExpirationUpdated(oldExpiration, 0);
+        emit TotalAssetsExpired();
+        emit SyncOperationsDisabled();
     }
 
     function decimalsOffset() internal view returns (uint8) {

--- a/src/v0.6.0/libraries/ERC7540Lib.sol
+++ b/src/v0.6.0/libraries/ERC7540Lib.sol
@@ -720,12 +720,16 @@ library ERC7540Lib {
 
     function isSyncRedeemAllowed() public view returns (bool) {
         SyncMode mode = _getERC7540Storage().syncMode;
-        return mode == SyncMode.SyncRedeem || mode == SyncMode.Both;
+        return (mode == SyncMode.SyncRedeem || mode == SyncMode.Both) && isTotalAssetsValid();
     }
 
     function isSyncDepositAllowed() public view returns (bool) {
         SyncMode mode = _getERC7540Storage().syncMode;
-        return mode == SyncMode.SyncDeposit || mode == SyncMode.Both;
+        return (mode == SyncMode.SyncDeposit || mode == SyncMode.Both) && isTotalAssetsValid();
+    }
+
+    function isTotalAssetsValid() public view returns (bool) {
+        return block.timestamp < _getERC7540Storage().totalAssetsExpiration;
     }
 
     function supportsInterface(

--- a/src/v0.6.0/libraries/ERC7540Lib.sol
+++ b/src/v0.6.0/libraries/ERC7540Lib.sol
@@ -31,7 +31,6 @@ import {
     SyncOperationsDisabled,
     SyncRedeemAllowedSwitched,
     TotalAssetsExpirationUpdated,
-    TotalAssetsExpired,
     TotalAssetsLifespanUpdated,
     TotalAssetsUpdated
 } from "../primitives/Events.sol";
@@ -194,7 +193,6 @@ library ERC7540Lib {
         $.isSyncRedeemAllowed = false;
 
         emit TotalAssetsExpirationUpdated(oldExpiration, 0);
-        emit TotalAssetsExpired();
         emit AsyncOnlyActivated();
     }
 
@@ -225,7 +223,6 @@ library ERC7540Lib {
         uint128 oldExpiration = $.totalAssetsExpiration;
         $.totalAssetsExpiration = 0;
         emit TotalAssetsExpirationUpdated(oldExpiration, 0);
-        emit TotalAssetsExpired();
         emit SyncOperationsDisabled();
     }
 

--- a/src/v0.6.0/libraries/VaultLib.sol
+++ b/src/v0.6.0/libraries/VaultLib.sol
@@ -59,7 +59,7 @@ library VaultLib {
         if (mode != SyncMode.SyncDeposit && mode != SyncMode.Both) {
             revert SyncOperationNotAllowed();
         }
-        if (!isTotalAssetsValid()) {
+        if (!ERC7540Lib.isTotalAssetsValid()) {
             revert TotalAssetsExpired();
         }
     }
@@ -70,20 +70,16 @@ library VaultLib {
         if (mode != SyncMode.SyncRedeem && mode != SyncMode.Both) {
             revert SyncOperationNotAllowed();
         }
-        if (!isTotalAssetsValid()) {
+        if (!ERC7540Lib.isTotalAssetsValid()) {
             revert TotalAssetsExpired();
         }
     }
 
     function _onlyAsyncDeposit() internal view {
         // if total assets is valid we can only do synchronous deposit
-        if (isTotalAssetsValid()) {
+        if (ERC7540Lib.isTotalAssetsValid()) {
             revert OnlySyncDepositAllowed();
         }
-    }
-
-    function isTotalAssetsValid() public view returns (bool) {
-        return block.timestamp < ERC7540Lib._getERC7540Storage().totalAssetsExpiration;
     }
 
     /// @notice Initiates the closing of the vault. Can only be called by the owner.

--- a/src/v0.6.0/libraries/VaultLib.sol
+++ b/src/v0.6.0/libraries/VaultLib.sol
@@ -3,8 +3,16 @@ pragma solidity 0.8.26;
 
 import {ERC7540} from "../ERC7540.sol";
 import {FeeLib} from "../libraries/FeeLib.sol";
-import {State} from "../primitives/Enums.sol";
-import {Closed, NotClosing, NotOpen, OnlyAsyncDepositAllowed, OnlySyncDepositAllowed} from "../primitives/Errors.sol";
+import {State, SyncMode} from "../primitives/Enums.sol";
+import {
+    Closed,
+    NotClosing,
+    NotOpen,
+    OnlyAsyncDepositAllowed,
+    OnlySyncDepositAllowed,
+    SyncOperationNotAllowed,
+    TotalAssetsExpired
+} from "../primitives/Errors.sol";
 import {StateUpdated} from "../primitives/Events.sol";
 import {VaultStorage} from "../primitives/VaultStorage.sol";
 import {ERC7540Lib} from "./ERC7540Lib.sol";
@@ -45,10 +53,25 @@ library VaultLib {
         if (_state == State.Closed) revert Closed();
     }
 
-    function _onlySyncDeposit() internal view {
-        // if total assets is not valid we can only do asynchronous deposit
+    function _syncDepositAllowed() internal view {
+        ERC7540.ERC7540Storage storage $ = ERC7540Lib._getERC7540Storage();
+        SyncMode mode = $.syncMode;
+        if (mode != SyncMode.SyncDeposit && mode != SyncMode.Both) {
+            revert SyncOperationNotAllowed();
+        }
         if (!isTotalAssetsValid()) {
-            revert OnlyAsyncDepositAllowed();
+            revert TotalAssetsExpired();
+        }
+    }
+
+    function _syncRedeemAllowed() internal view {
+        ERC7540.ERC7540Storage storage $ = ERC7540Lib._getERC7540Storage();
+        SyncMode mode = $.syncMode;
+        if (mode != SyncMode.SyncRedeem && mode != SyncMode.Both) {
+            revert SyncOperationNotAllowed();
+        }
+        if (!isTotalAssetsValid()) {
+            revert TotalAssetsExpired();
         }
     }
 

--- a/src/v0.6.0/primitives/Enums.sol
+++ b/src/v0.6.0/primitives/Enums.sol
@@ -24,3 +24,12 @@ enum AccessMode {
     Blacklist,
     Whitelist
 }
+
+// ********************* ERC7540 ********************* //
+
+enum SyncMode {
+    Both, // Both sync deposit and sync redeem are allowed (default)
+    SyncDeposit, // Only sync deposit is allowed
+    SyncRedeem, // Only sync redeem is allowed
+    None // No sync operations are allowed
+}

--- a/src/v0.6.0/primitives/Errors.sol
+++ b/src/v0.6.0/primitives/Errors.sol
@@ -118,9 +118,6 @@ error OnlyWhitelistManager(address whitelistManager);
 /// @param valuationManager The address of the valuation manager.
 error OnlyValuationManager(address valuationManager);
 
-/// @notice Indicates that the safe upgradeability has been given up..
-error SafeUpgradeabilityNotAllowed();
-
 /// @notice Indicates that the caller is not the security council.
 /// @param securityCouncil The address of the security council.
 error OnlySecurityCouncil(address securityCouncil);

--- a/src/v0.6.0/primitives/Errors.sol
+++ b/src/v0.6.0/primitives/Errors.sol
@@ -61,17 +61,17 @@ error WrongNewTotalAssets();
 /// @notice Indicates that totalAssets value is outdated and that synchronous deposits are not allowed.
 error OnlyAsyncDepositAllowed();
 
+/// @notice Indicates that the total assets value is expired.
+error TotalAssetsExpired();
+
 /// @notice Indicates that deposit can only happen via the synchronous path.
 error OnlySyncDepositAllowed();
 
 /// @notice Indicates that the max cap is reached.
 error MaxCapReached();
 
-/// @notice Indicates that sync redeem is not allowed.
-error SyncRedeemNotAllowed();
-
-/// @notice Can't enable sync redeem
-error EnableSyncRedeemNotAllowed();
+/// @notice Indicates that the sync operation is not allowed by the current sync mode.
+error SyncOperationNotAllowed();
 
 /// @notice Only asynchronous operations are allowed.
 error AsyncOnly();

--- a/src/v0.6.0/primitives/Events.sol
+++ b/src/v0.6.0/primitives/Events.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.26;
 
-import {AccessMode, FeeType, State} from "./Enums.sol";
+import {AccessMode, FeeType, State, SyncMode} from "./Enums.sol";
 import {Rates} from "./Struct.sol";
 import {Guardrails} from "./Struct.sol";
 
@@ -142,9 +142,6 @@ event DepositRequestCanceled(uint256 indexed requestId, address indexed controll
 /// @param newExpiration The new expiration timestamp.
 event TotalAssetsExpirationUpdated(uint128 oldExpiration, uint128 newExpiration);
 
-/// @notice Emitted when synchronous operations are disabled.
-event SyncOperationsDisabled();
-
 /// @notice Emitted when the lifespan is updated.
 /// @param oldLifespan The old lifespan.
 /// @param newLifespan The new lifespan.
@@ -209,6 +206,7 @@ event NameUpdated(string previousName, string newName);
 /// @param newSymbol The new symbol of the ERC20 token.
 event SymbolUpdated(string previousSymbol, string newSymbol);
 
-/// @notice Emitted when the sync redeem allowed is switched.
-/// @param isSyncRedeemAllowed The new sync redeem allowed status.
-event SyncRedeemAllowedSwitched(bool isSyncRedeemAllowed);
+/// @notice Emitted when the sync mode is updated.
+/// @param oldMode The previous sync mode.
+/// @param newMode The new sync mode.
+event SyncModeUpdated(SyncMode oldMode, SyncMode newMode);

--- a/src/v0.6.0/primitives/Events.sol
+++ b/src/v0.6.0/primitives/Events.sol
@@ -78,9 +78,6 @@ event ValuationManagerUpdated(address oldManager, address newManager);
 /// @param newSafe The address of the new safe.
 event SafeUpdated(address oldSafe, address newSafe);
 
-/// @notice Emitted when the safe upgradeability is given up.
-event SafeUpgradeabilityGivenUp();
-
 /// @notice Emitted when the security council role is updated.
 /// @param oldSecurityCouncil The address of the old security council.
 /// @param newSecurityCouncil The address of the new security council.

--- a/src/v0.6.0/primitives/Events.sol
+++ b/src/v0.6.0/primitives/Events.sol
@@ -140,6 +140,18 @@ event NewTotalAssetsUpdated(uint256 totalAssets);
 /// @param controller The address of the controller of the canceled request.
 event DepositRequestCanceled(uint256 indexed requestId, address indexed controller);
 
+/// @notice Emitted when the total assets expiration is updated.
+/// @param oldExpiration The previous expiration timestamp.
+/// @param newExpiration The new expiration timestamp.
+event TotalAssetsExpirationUpdated(uint128 oldExpiration, uint128 newExpiration);
+
+/// @notice Emitted when the total assets expiration is reset (expired).
+/// @dev Kept for backward compatibility. TotalAssetsExpirationUpdated is also emitted.
+event TotalAssetsExpired();
+
+/// @notice Emitted when synchronous operations are disabled.
+event SyncOperationsDisabled();
+
 /// @notice Emitted when the lifespan is updated.
 /// @param oldLifespan The old lifespan.
 /// @param newLifespan The new lifespan.

--- a/src/v0.6.0/primitives/Events.sol
+++ b/src/v0.6.0/primitives/Events.sol
@@ -142,10 +142,6 @@ event DepositRequestCanceled(uint256 indexed requestId, address indexed controll
 /// @param newExpiration The new expiration timestamp.
 event TotalAssetsExpirationUpdated(uint128 oldExpiration, uint128 newExpiration);
 
-/// @notice Emitted when the total assets expiration is reset (expired).
-/// @dev Kept for backward compatibility. TotalAssetsExpirationUpdated is also emitted.
-event TotalAssetsExpired();
-
 /// @notice Emitted when synchronous operations are disabled.
 event SyncOperationsDisabled();
 

--- a/src/v0.6.0/primitives/Events.sol
+++ b/src/v0.6.0/primitives/Events.sol
@@ -140,6 +140,12 @@ event NewTotalAssetsUpdated(uint256 totalAssets);
 /// @param controller The address of the controller of the canceled request.
 event DepositRequestCanceled(uint256 indexed requestId, address indexed controller);
 
+/// @notice Emitted when a redeem request is canceled.
+/// @param requestId The ID of the canceled request.
+/// @param controller The address of the controller of the canceled request.
+/// @param requestedAmount The amount of assets requested in the redeem request.
+event RedeemRequestCanceled(uint256 indexed requestId, address indexed controller, uint256 requestedAmount);
+
 /// @notice Emitted when the lifespan is updated.
 /// @param oldLifespan The old lifespan.
 /// @param newLifespan The new lifespan.

--- a/src/v0.6.0/vault/Vault-v0.6.0.sol
+++ b/src/v0.6.0/vault/Vault-v0.6.0.sol
@@ -683,7 +683,7 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
     function previewSyncDeposit(
         uint256 assets
     ) public view returns (uint256 shares) {
-        if (paused() || !isTotalAssetsValid() || !ERC7540Lib.isSyncDepositAllowed()) return 0;
+        if (paused() || !ERC7540Lib.isSyncDepositAllowed()) return 0;
         shares = _convertToShares(assets, Math.Rounding.Floor);
         uint256 entryFeeShares = FeeLib.computeFee(shares, FeeLib.feeRates().entryRate);
         shares -= entryFeeShares;
@@ -693,7 +693,7 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
     function previewSyncRedeem(
         uint256 shares
     ) public view returns (uint256 assets) {
-        if (paused() || !isTotalAssetsValid() || !ERC7540Lib.isSyncRedeemAllowed()) return 0;
+        if (paused() || !ERC7540Lib.isSyncRedeemAllowed()) return 0;
         uint256 exitFeeShares = FeeLib.computeFee(shares, FeeLib.feeRates().exitRate);
         uint256 haircutShares = FeeLib.computeFee(shares - exitFeeShares, FeeLib.feeRates().haircutRate);
         assets = _convertToAssets(shares - exitFeeShares - haircutShares, Math.Rounding.Floor);
@@ -701,7 +701,7 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
     }
 
     function isTotalAssetsValid() public view returns (bool) {
-        return VaultLib.isTotalAssetsValid();
+        return ERC7540Lib.isTotalAssetsValid();
     }
 
     function isAllowed(

--- a/src/v0.6.0/vault/Vault-v0.6.0.sol
+++ b/src/v0.6.0/vault/Vault-v0.6.0.sol
@@ -30,7 +30,14 @@ import {
 
 import {GuardrailsManager} from "../GuardRailsManager.sol";
 
-import {DepositSync, HaircutTaken, Referral, WithdrawSync} from "../primitives/Events.sol";
+import {
+    DepositSync,
+    HaircutTaken,
+    Referral,
+    TotalAssetsExpirationUpdated,
+    TotalAssetsExpired,
+    WithdrawSync
+} from "../primitives/Events.sol";
 import {ERC4626Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -485,6 +492,11 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
             revert ValuationUpdateNotAllowed();
         }
 
+        // if sync redeem is allowed,
+        // we do not allow the security council to propose a new nav
+        // it must call disable synchronous redemptions first.
+        if (ERC7540Lib._getERC7540Storage().isSyncRedeemAllowed) revert ValuationUpdateNotAllowed();
+
         ERC7540Lib.updateNewTotalAssets(_newTotalAssets);
     }
 
@@ -579,7 +591,10 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
     /// @notice Expires the total assets, disabling sync deposits.
     /// @dev Can only be called by the safe.
     function expireTotalAssets() public onlySafe {
+        uint128 oldExpiration = ERC7540Lib._getERC7540Storage().totalAssetsExpiration;
         ERC7540Lib._getERC7540Storage().totalAssetsExpiration = 0;
+        emit TotalAssetsExpirationUpdated(oldExpiration, 0);
+        emit TotalAssetsExpired();
     }
 
     /// @notice Disables synchronous operations for the vault.
@@ -682,7 +697,7 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
     function previewSyncRedeem(
         uint256 shares
     ) public view returns (uint256 assets) {
-        if (paused() || !isTotalAssetsValid() || !ERC7540Lib.isSyncRedeemAllowed()) return 0;
+        if (paused() || !ERC7540Lib.isSyncRedeemAllowed()) return 0;
         uint256 exitFeeShares = FeeLib.computeFee(shares, FeeLib.feeRates().exitRate);
         uint256 haircutShares = FeeLib.computeFee(shares - exitFeeShares, FeeLib.feeRates().haircutRate);
         assets = _convertToAssets(shares - exitFeeShares - haircutShares, Math.Rounding.Floor);

--- a/src/v0.6.0/vault/Vault-v0.6.0.sol
+++ b/src/v0.6.0/vault/Vault-v0.6.0.sol
@@ -6,7 +6,7 @@ import {ERC7540Lib} from "../libraries/ERC7540Lib.sol";
 import {FeeLib} from "../libraries/FeeLib.sol";
 import {RolesLib} from "../libraries/RolesLib.sol";
 import {VaultLib} from "../libraries/VaultLib.sol";
-import {FeeType} from "../primitives/Enums.sol";
+import {FeeType, SyncMode} from "../primitives/Enums.sol";
 import {VaultStorage} from "../primitives/VaultStorage.sol";
 
 import {VaultInit} from "./VaultInit.sol";
@@ -134,15 +134,21 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
         _;
     }
 
-    /// @notice Reverts if totalAssets is expired.
-    modifier onlySyncDeposit() {
-        VaultLib._onlySyncDeposit();
+    /// @notice Reverts if totalAssets is expired or sync deposit is not allowed.
+    modifier syncDepositAllowed() {
+        VaultLib._syncDepositAllowed();
         _;
     }
 
     /// @notice Reverts if totalAssets is valid.
     modifier onlyAsyncDeposit() {
         VaultLib._onlyAsyncDeposit();
+        _;
+    }
+
+    /// @notice Reverts if totalAssets is expired or sync redeem is not allowed.
+    modifier syncRedeemAllowed() {
+        VaultLib._syncRedeemAllowed();
         _;
     }
 
@@ -184,7 +190,7 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
         uint256 assets,
         address receiver,
         address referral
-    ) public payable onlySyncDeposit onlyOpen returns (uint256 shares) {
+    ) public payable syncDepositAllowed onlyOpen returns (uint256 shares) {
         if (!isAllowed(msg.sender)) revert AddressNotAllowed(msg.sender);
         if (!isAllowed(receiver)) revert AddressNotAllowed(receiver);
 
@@ -230,7 +236,7 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
         uint256 shares,
         address receiver,
         uint256 minimumAssets
-    ) public onlyOpen onlySyncRedeemAllowed returns (uint256 assets) {
+    ) public onlyOpen syncRedeemAllowed returns (uint256 assets) {
         if (!isAllowed(msg.sender)) revert AddressNotAllowed(msg.sender);
         if (!isAllowed(receiver)) revert AddressNotAllowed(receiver);
         if (receiver == address(0)) revert InvalidReceiver(receiver);
@@ -448,17 +454,12 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
             revert Closed();
         }
 
-        // if totalAssets is not expired yet it means syncDeposit are allowed
+        // if totalAssets is not expired yet it means sync operations are allowed
         // in this case we do not allow the valuation manager to propose a new nav
-        // he must call unvalidateTotalAssets first.
+        // he must call expireTotalAssets first.
         if (isTotalAssetsValid()) {
             revert ValuationUpdateNotAllowed();
         }
-
-        // if sync redeem is allowed,
-        // we do not allow the valuation manager to propose a new nav
-        // he must call disable synchronous redemptions first.
-        if (ERC7540Lib._getERC7540Storage().isSyncRedeemAllowed) revert ValuationUpdateNotAllowed();
 
         uint256 oneShare = 10 ** decimals();
         uint256 currentPps = convertToAssets(oneShare);
@@ -490,11 +491,6 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
         if (isTotalAssetsValid()) {
             revert ValuationUpdateNotAllowed();
         }
-
-        // if sync redeem is allowed,
-        // we do not allow the security council to propose a new nav
-        // it must call disable synchronous redemptions first.
-        if (ERC7540Lib._getERC7540Storage().isSyncRedeemAllowed) revert ValuationUpdateNotAllowed();
 
         ERC7540Lib.updateNewTotalAssets(_newTotalAssets);
     }
@@ -541,14 +537,22 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
         _updateMaxCap(_maxCap);
     }
 
-    ////////////////////////////////
-    // ## SYNC REDEEM ALLOWED ## //
-    ////////////////////////////////
+    //////////////////////////
+    // ## SYNC MODE ## //
+    //////////////////////////
 
-    function setIsSyncRedeemAllowed(
-        bool _isAllowed
+    /// @notice Updates the sync mode for the vault.
+    /// @param _mode The new sync mode.
+    /// @dev Can only be called by the safe. Reverts if the vault is in async-only mode.
+    function setSyncMode(
+        SyncMode _mode
     ) external onlySafe {
-        ERC7540Lib.setIsSyncRedeemAllowed(_isAllowed);
+        ERC7540Lib.setSyncMode(_mode);
+    }
+
+    /// @notice Returns the current sync mode.
+    function syncMode() public view returns (SyncMode) {
+        return ERC7540Lib._getERC7540Storage().syncMode;
     }
 
     /////////////////////////////
@@ -593,12 +597,6 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
         uint128 oldExpiration = ERC7540Lib._getERC7540Storage().totalAssetsExpiration;
         ERC7540Lib._getERC7540Storage().totalAssetsExpiration = 0;
         emit TotalAssetsExpirationUpdated(oldExpiration, 0);
-    }
-
-    /// @notice Disables synchronous operations for the vault.
-    /// @dev Can only be called by the safe.
-    function disableSyncOperations() public onlySafe {
-        ERC7540Lib.disableSyncOperations();
     }
 
     /// @notice Resets the high water mark to the current price per share.
@@ -685,7 +683,7 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
     function previewSyncDeposit(
         uint256 assets
     ) public view returns (uint256 shares) {
-        if (paused() || !isTotalAssetsValid()) return 0;
+        if (paused() || !isTotalAssetsValid() || !ERC7540Lib.isSyncDepositAllowed()) return 0;
         shares = _convertToShares(assets, Math.Rounding.Floor);
         uint256 entryFeeShares = FeeLib.computeFee(shares, FeeLib.feeRates().entryRate);
         shares -= entryFeeShares;
@@ -695,7 +693,7 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
     function previewSyncRedeem(
         uint256 shares
     ) public view returns (uint256 assets) {
-        if (paused() || !ERC7540Lib.isSyncRedeemAllowed()) return 0;
+        if (paused() || !isTotalAssetsValid() || !ERC7540Lib.isSyncRedeemAllowed()) return 0;
         uint256 exitFeeShares = FeeLib.computeFee(shares, FeeLib.feeRates().exitRate);
         uint256 haircutShares = FeeLib.computeFee(shares - exitFeeShares, FeeLib.feeRates().haircutRate);
         assets = _convertToAssets(shares - exitFeeShares - haircutShares, Math.Rounding.Floor);

--- a/src/v0.6.0/vault/Vault-v0.6.0.sol
+++ b/src/v0.6.0/vault/Vault-v0.6.0.sol
@@ -35,7 +35,6 @@ import {
     HaircutTaken,
     Referral,
     TotalAssetsExpirationUpdated,
-    TotalAssetsExpired,
     WithdrawSync
 } from "../primitives/Events.sol";
 import {ERC4626Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
@@ -594,7 +593,6 @@ contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
         uint128 oldExpiration = ERC7540Lib._getERC7540Storage().totalAssetsExpiration;
         ERC7540Lib._getERC7540Storage().totalAssetsExpiration = 0;
         emit TotalAssetsExpirationUpdated(oldExpiration, 0);
-        emit TotalAssetsExpired();
     }
 
     /// @notice Disables synchronous operations for the vault.

--- a/test/v0.6.0/AsyncOnly.t.sol
+++ b/test/v0.6.0/AsyncOnly.t.sol
@@ -6,7 +6,8 @@ import "forge-std/Test.sol";
 
 import {BaseTest} from "./Base.sol";
 import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {AsyncOnly, OnlyAsyncDepositAllowed} from "@src/v0.6.0/primitives/Errors.sol";
+import {SyncMode} from "@src/v0.6.0/primitives/Enums.sol";
+import {AsyncOnly, OnlyAsyncDepositAllowed, SyncOperationNotAllowed} from "@src/v0.6.0/primitives/Errors.sol";
 import {AsyncOnlyActivated} from "@src/v0.6.0/primitives/Events.sol";
 
 // Tests for the ActivateAsyncOnly functionality
@@ -165,7 +166,7 @@ contract TestAsyncOnly is BaseTest {
 
         dealAndApproveAndWhitelist(user2.addr);
         vm.prank(user2.addr);
-        vm.expectRevert(OnlyAsyncDepositAllowed.selector);
+        vm.expectRevert(SyncOperationNotAllowed.selector);
         vault.syncDeposit(100 * 10 ** underlyingDecimals, user2.addr, address(0));
     }
 
@@ -179,21 +180,18 @@ contract TestAsyncOnly is BaseTest {
 
         uint256 shares = vault.balanceOf(user1.addr);
 
-        vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
-
-        // Disable sync deposit forever
+        // Disable sync operations forever
         vm.prank(vault.owner());
         vault.activateAsyncOnly();
 
-        // Allow sync redeem
+        // Try to set sync mode - should revert
         vm.prank(vault.safe());
         vm.expectRevert(AsyncOnly.selector);
-        vault.setIsSyncRedeemAllowed(true);
+        vault.setSyncMode(SyncMode.SyncRedeem);
 
         // Try to sync redeem - should revert
         vm.prank(user1.addr);
-        vm.expectRevert(SyncRedeemNotAllowed.selector);
+        vm.expectRevert(SyncOperationNotAllowed.selector);
         vault.syncRedeem(shares / 2, user1.addr, 0);
     }
 

--- a/test/v0.6.0/CancelRequestRedeem.t.sol
+++ b/test/v0.6.0/CancelRequestRedeem.t.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import "./VaultHelper.sol";
+import "forge-std/Test.sol";
+
+import {BaseTest} from "./Base.sol";
+import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {AccessMode} from "@src/v0.6.0/primitives/Enums.sol";
+
+contract TestCancelRequestRedeem is BaseTest {
+    uint256 shares;
+
+    function setUp() public {
+        enableWhitelist = false;
+        setUpVault(0, 0, 0);
+        dealAndApprove(user1.addr);
+        dealAndApprove(user2.addr);
+        uint256 user1Assets = assetBalance(user1.addr);
+
+        // Deposit for user1 so they have shares
+        requestDeposit(user1Assets / 2, user1.addr);
+        updateAndSettle(0);
+        deposit(user1Assets / 2, user1.addr);
+        vm.warp(block.timestamp + 1 days);
+
+        // user1 requests a redeem
+        shares = balance(user1.addr) / 2;
+        requestRedeem(shares, user1.addr);
+    }
+
+    function test_cancelRequestRedeem_selfCancel() public {
+        uint256 sharesBefore = balance(user1.addr);
+        uint256 requestId = vault.redeemEpochId();
+
+        assertEq(vault.pendingRedeemRequest(requestId, user1.addr), shares);
+
+        vm.prank(user1.addr);
+        vm.expectEmit(address(vault));
+        emit RedeemRequestCanceled(requestId, user1.addr, shares);
+        vault.cancelRequestRedeem(user1.addr);
+
+        assertEq(vault.pendingRedeemRequest(requestId, user1.addr), 0);
+        assertEq(balance(user1.addr), sharesBefore + shares);
+    }
+
+    function test_cancelRequestRedeem_revertsWhenNewTotalAssetsHasBeenUpdated() public {
+        uint256 requestId = vault.lastRedeemRequestId(user1.addr);
+
+        updateNewTotalAssets(0);
+
+        vm.prank(user1.addr);
+        vm.expectRevert(abi.encodeWithSelector(RequestNotCancelable.selector, requestId));
+        vault.cancelRequestRedeem(user1.addr);
+    }
+
+    function test_cancelRequestRedeem_asSuperOperator() public {
+        uint256 sharesBefore = balance(user1.addr);
+
+        vm.prank(superOperator.addr);
+        vault.cancelRequestRedeem(user1.addr);
+
+        assertEq(balance(user1.addr), sharesBefore + shares);
+    }
+
+    function test_cancelRequestRedeem_whenBlacklisted() public {
+        // Switch to blacklist mode and blacklist user1
+        vm.prank(vault.owner());
+        vault.switchAccessMode(AccessMode.Blacklist);
+        blacklist(user1.addr);
+
+        uint256 sharesBefore = balance(user1.addr);
+
+        vm.prank(user1.addr);
+        vault.cancelRequestRedeem(user1.addr);
+
+        assertEq(balance(user1.addr), sharesBefore + shares);
+    }
+
+    function test_cancelRequestRedeem_whenPaused_shouldRevert() public {
+        vm.prank(vault.owner());
+        vault.pause();
+
+        vm.prank(user1.addr);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vault.cancelRequestRedeem(user1.addr);
+    }
+
+    function test_cancelRequestRedeem_asOperator() public {
+        vm.prank(user1.addr);
+        vault.setOperator(user2.addr, true);
+
+        uint256 sharesBefore = balance(user1.addr);
+
+        vm.prank(user2.addr);
+        vault.cancelRequestRedeem(user1.addr);
+
+        assertEq(balance(user1.addr), sharesBefore + shares);
+    }
+
+    function test_cancelRequestRedeem_notOperator_shouldRevert() public {
+        vm.prank(user2.addr);
+        vm.expectRevert(ERC7540InvalidOperator.selector);
+        vault.cancelRequestRedeem(user1.addr);
+    }
+
+    function test_cancelRequestRedeem_superOperator_forProtocolFeeReceiver_shouldRevert() public {
+        address protocolFeeReceiver = vault.protocolFeeReceiver();
+
+        vm.prank(superOperator.addr);
+        vm.expectRevert(ERC7540InvalidOperator.selector);
+        vault.cancelRequestRedeem(protocolFeeReceiver);
+    }
+}

--- a/test/v0.6.0/StorageCollision.t.sol
+++ b/test/v0.6.0/StorageCollision.t.sol
@@ -55,12 +55,12 @@ contract TestStorageCollision is BaseTest {
         _vault = VaultHelper_v0_5_1(
             OptinProxyFactory_v0_5_0(address(factory))
                 .createVaultProxy({
-                    _logic: address(0),
-                    _initialOwner: initStruct.admin,
-                    _initialDelay: 86_400,
-                    _init: initStruct,
-                    salt: keccak256("42")
-                })
+                _logic: address(0),
+                _initialOwner: initStruct.admin,
+                _initialDelay: 86_400,
+                _init: initStruct,
+                salt: keccak256("42")
+            })
         );
         proxyV0_6_0 = VaultHelper_v0_6_0(address(_vault));
         assertEq(_vault.version(), "v0.5.1");

--- a/test/v0.6.0/SyncDeposit.t.sol
+++ b/test/v0.6.0/SyncDeposit.t.sol
@@ -8,6 +8,7 @@ import {BaseTest} from "./Base.sol";
 import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {SyncMode} from "@src/v0.6.0/primitives/Enums.sol";
 
 contract TestSyncDeposit is BaseTest {
     using Math for uint256;
@@ -47,7 +48,7 @@ contract TestSyncDeposit is BaseTest {
         // we go one second after the expiration
         vm.warp(block.timestamp + 1001);
 
-        vm.expectRevert(OnlyAsyncDepositAllowed.selector);
+        vm.expectRevert(TotalAssetsExpired.selector);
         vm.prank(user1.addr);
         vault.syncDeposit(1, user1.addr, address(0));
     }
@@ -119,12 +120,14 @@ contract TestSyncDeposit is BaseTest {
         vault.initiateClosing();
 
         vm.prank(safe.addr);
-        vault.disableSyncOperations();
+        vault.setSyncMode(SyncMode.None);
+        vm.prank(safe.addr);
+        vault.expireTotalAssets();
 
         updateNewTotalAssets(vault.totalAssets());
         vm.stopPrank();
 
-        vm.expectRevert(OnlyAsyncDepositAllowed.selector);
+        vm.expectRevert(SyncOperationNotAllowed.selector);
         vm.prank(user1.addr);
         vault.syncDeposit(1, user1.addr, address(0));
 
@@ -132,9 +135,8 @@ contract TestSyncDeposit is BaseTest {
         vault.close(vault.newTotalAssets());
         vm.stopPrank();
 
-        // make sure he is wl
-
-        vm.expectRevert(abi.encodeWithSelector(NotOpen.selector, State.Closed));
+        // syncMode is None, so SyncOperationNotAllowed fires before NotOpen
+        vm.expectRevert(SyncOperationNotAllowed.selector);
         vm.prank(user1.addr);
         vault.syncDeposit(1, user1.addr, address(0));
     }

--- a/test/v0.6.0/SyncRedeem.t.sol
+++ b/test/v0.6.0/SyncRedeem.t.sol
@@ -8,7 +8,7 @@ import {BaseTest} from "./Base.sol";
 import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
-import {State} from "@src/v0.6.0/primitives/Enums.sol";
+import {State, SyncMode} from "@src/v0.6.0/primitives/Enums.sol";
 import {WithdrawSync} from "@src/v0.6.0/primitives/Events.sol";
 import {Rates} from "@src/v0.6.0/primitives/Struct.sol";
 
@@ -29,7 +29,7 @@ contract TestSyncRedeem is BaseTest {
         updateAndSettle(0);
         vm.warp(block.timestamp + 1);
         vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
+        vault.setSyncMode(SyncMode.Both);
     }
 
     function test_syncRedeem_simple() public {
@@ -60,7 +60,7 @@ contract TestSyncRedeem is BaseTest {
         assertEq(vault.totalAssets(), totalAssetsBefore - assets, "totalAssets not decreased correctly");
     }
 
-    function test_syncRedeem_lifespanOutdateShouldStillWork() public {
+    function test_syncRedeem_lifespanOutdateShouldRevert() public {
         // First deposit to get shares
         uint256 depositAmount = assetBalance(user1.addr);
         vm.prank(user1.addr);
@@ -69,6 +69,7 @@ contract TestSyncRedeem is BaseTest {
         // we go one second after the expiration
         vm.warp(block.timestamp + 1001);
 
+        vm.expectRevert(TotalAssetsExpired.selector);
         vm.prank(user1.addr);
         vault.syncRedeem(1, user1.addr, 0);
     }
@@ -89,7 +90,9 @@ contract TestSyncRedeem is BaseTest {
         vault.initiateClosing();
 
         vm.prank(safe.addr);
-        vault.disableSyncOperations();
+        vault.setSyncMode(SyncMode.None);
+        vm.prank(safe.addr);
+        vault.expireTotalAssets();
 
         updateNewTotalAssets(vault.totalAssets());
         vm.stopPrank();
@@ -179,7 +182,7 @@ contract TestSyncRedeem is BaseTest {
         vault.updateTotalAssetsLifespan(1000);
         updateAndSettle(0);
         vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
+        vault.setSyncMode(SyncMode.Both);
 
         // Deposit to get shares
         uint256 depositAmount = assetBalance(user1.addr);
@@ -234,7 +237,7 @@ contract TestSyncRedeem is BaseTest {
         updateAndSettle(0);
 
         vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
+        vault.setSyncMode(SyncMode.Both);
 
         // Deposit to get shares
         uint256 depositAmount = assetBalance(user1.addr);
@@ -273,7 +276,7 @@ contract TestSyncRedeem is BaseTest {
         vault.updateTotalAssetsLifespan(1000);
         updateAndSettle(0);
         vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
+        vault.setSyncMode(SyncMode.Both);
 
         // Deposit to get shares
         uint256 depositAmount = assetBalance(user1.addr);
@@ -321,7 +324,7 @@ contract TestSyncRedeem is BaseTest {
         updateAndSettle(0);
 
         vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
+        vault.setSyncMode(SyncMode.Both);
 
         // Deposit to get shares
         uint256 depositAmount = assetBalance(user1.addr);
@@ -425,9 +428,9 @@ contract TestSyncRedeem is BaseTest {
 
     function test_syncRedeem_notAllowed() public {
         vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(false);
+        vault.setSyncMode(SyncMode.SyncDeposit);
 
-        vm.expectRevert(SyncRedeemNotAllowed.selector);
+        vm.expectRevert(SyncOperationNotAllowed.selector);
         vm.prank(user1.addr);
         vault.syncRedeem(1, user1.addr, 0);
     }
@@ -448,7 +451,7 @@ contract TestSyncRedeem is BaseTest {
         updateAndSettle(0);
 
         vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
+        vault.setSyncMode(SyncMode.Both);
         // Deposit to get shares
         uint256 depositAmount = assetBalance(user1.addr);
         vm.prank(user1.addr);

--- a/test/v0.6.0/TotalAssetsExpiry.t.sol
+++ b/test/v0.6.0/TotalAssetsExpiry.t.sol
@@ -37,7 +37,7 @@ contract TestTotalAssetsExpiry is BaseTest {
 
         vm.prank(vault.valuationManager());
         vm.expectRevert(abi.encodeWithSelector(OnlySafe.selector, vault.safe()));
-        vault.disableSyncOperations();
+        vault.expireTotalAssets();
     }
 
     function test_whenTotalAssetsExpireWithTime_canUpdateNav() public {
@@ -58,7 +58,7 @@ contract TestTotalAssetsExpiry is BaseTest {
         vault.updateNewTotalAssets(1);
 
         vm.prank(vault.safe());
-        vault.disableSyncOperations();
+        vault.expireTotalAssets();
 
         assertEq(vault.totalAssetsExpiration(), 0, "ttA is not expired");
     }

--- a/test/v0.6.0/UpdateNewTotalAssets.t.sol
+++ b/test/v0.6.0/UpdateNewTotalAssets.t.sol
@@ -104,6 +104,41 @@ contract TestUpdateNewTotalAssets is BaseTest {
         vault.setIsSyncRedeemAllowed(true);
     }
 
+    // --- isSyncRedeemAllowed blocks securityCouncilUpdateTotalAssets ---
+
+    function test_securityCouncil_whenSyncRedeemAllowed_cantUpdateNav() public {
+        // let totalAssets lifespan expire so only isSyncRedeemAllowed blocks
+        vm.warp(block.timestamp + 1 days);
+
+        vm.prank(vault.safe());
+        vault.setIsSyncRedeemAllowed(true);
+
+        vm.prank(vault.securityCouncil());
+        vm.expectRevert(ValuationUpdateNotAllowed.selector);
+        vault.securityCouncilUpdateTotalAssets(1);
+    }
+
+    function test_securityCouncil_disableSyncOperations_clearsSyncRedeemAllowed() public {
+        vm.warp(block.timestamp + 1 days);
+
+        vm.prank(vault.safe());
+        vault.setIsSyncRedeemAllowed(true);
+
+        // verify blocked
+        vm.prank(vault.securityCouncil());
+        vm.expectRevert(ValuationUpdateNotAllowed.selector);
+        vault.securityCouncilUpdateTotalAssets(1);
+
+        // disableSyncOperations should clear isSyncRedeemAllowed
+        vm.prank(vault.safe());
+        vault.disableSyncOperations();
+
+        vm.prank(vault.securityCouncil());
+        vault.securityCouncilUpdateTotalAssets(1);
+    }
+
+    // --- setIsSyncRedeemAllowed reverts in asyncOnly mode ---
+
     function test_setIsSyncRedeemAllowed_disableAlsoRevertsWhenNewTotalAssetsPending() public {
         // enable sync redeem first (while newTotalAssets == max)
         vm.prank(vault.safe());

--- a/test/v0.6.0/UpdateNewTotalAssets.t.sol
+++ b/test/v0.6.0/UpdateNewTotalAssets.t.sol
@@ -5,6 +5,7 @@ import "./VaultHelper.sol";
 import "forge-std/Test.sol";
 
 import {BaseTest} from "./Base.sol";
+import {SyncMode} from "@src/v0.6.0/primitives/Enums.sol";
 
 contract TestUpdateNewTotalAssets is BaseTest {
     function setUp() public {
@@ -16,144 +17,79 @@ contract TestUpdateNewTotalAssets is BaseTest {
         updateAndSettle(0);
     }
 
-    // --- isSyncRedeemAllowed blocks updateNewTotalAssets ---
+    // --- isTotalAssetsValid blocks updateNewTotalAssets ---
 
-    function test_whenSyncRedeemAllowed_cantUpdateNav() public {
-        // let totalAssets lifespan expire so only isSyncRedeemAllowed blocks
-        vm.warp(block.timestamp + 1 days);
-
-        vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
-
+    function test_whenTotalAssetsValid_cantUpdateNav() public {
         vm.prank(vault.valuationManager());
         vm.expectRevert(ValuationUpdateNotAllowed.selector);
         vault.updateNewTotalAssets(1);
     }
 
-    function test_whenSyncRedeemDisabled_canUpdateNav() public {
+    function test_whenTotalAssetsExpired_canUpdateNav() public {
         vm.warp(block.timestamp + 1 days);
-
-        // enable then disable sync redeem
-        vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
-
-        vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(false);
 
         vm.prank(vault.valuationManager());
         vault.updateNewTotalAssets(1);
     }
 
-    function test_disableSyncOperations_clearsSyncRedeemAllowed() public {
-        vm.warp(block.timestamp + 1 days);
-
-        vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
-
-        // verify blocked
+    function test_expireTotalAssets_allowsUpdateNav() public {
         vm.prank(vault.valuationManager());
         vm.expectRevert(ValuationUpdateNotAllowed.selector);
         vault.updateNewTotalAssets(1);
 
-        // disableSyncOperations should clear isSyncRedeemAllowed
         vm.prank(vault.safe());
-        vault.disableSyncOperations();
+        vault.expireTotalAssets();
 
         vm.prank(vault.valuationManager());
         vault.updateNewTotalAssets(1);
     }
 
-    // --- setAsyncOnly clears isSyncRedeemAllowed ---
+    // --- syncMode does NOT block updateNewTotalAssets ---
 
-    function test_setAsyncOnly_clearsSyncRedeemAllowed() public {
-        vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
+    function test_syncModeDoesNotBlockUpdateNav() public {
+        // let totalAssets expire
+        vm.warp(block.timestamp + 1 days);
 
+        // even with syncMode = Both (default), updateNewTotalAssets succeeds
+        // because only isTotalAssetsValid gates it
+        vm.prank(vault.valuationManager());
+        vault.updateNewTotalAssets(1);
+    }
+
+    // --- setAsyncOnly clears syncMode ---
+
+    function test_setAsyncOnly_clearsSyncMode() public {
         vm.prank(vault.owner());
         vault.activateAsyncOnly();
 
-        // should succeed: setAsyncOnly clears isSyncRedeemAllowed
+        // should succeed: setAsyncOnly expires totalAssets
         vm.prank(vault.valuationManager());
         vault.updateNewTotalAssets(1);
     }
 
-    // --- setIsSyncRedeemAllowed reverts in asyncOnly mode ---
+    // --- setSyncMode reverts in asyncOnly mode ---
 
-    function test_setIsSyncRedeemAllowed_revertsWhenAsyncOnly() public {
+    function test_setSyncMode_revertsWhenAsyncOnly() public {
         vm.prank(vault.owner());
         vault.activateAsyncOnly();
 
         vm.prank(vault.safe());
         vm.expectRevert(AsyncOnly.selector);
-        vault.setIsSyncRedeemAllowed(true);
+        vault.setSyncMode(SyncMode.SyncRedeem);
     }
 
-    // --- setIsSyncRedeemAllowed reverts when newTotalAssets is pending ---
+    // --- securityCouncil ---
 
-    function test_setIsSyncRedeemAllowed_revertsWhenNewTotalAssetsPending() public {
-        // let totalAssets lifespan expire so updateNewTotalAssets succeeds
-        vm.warp(block.timestamp + 1 days);
-
-        // propose a new NAV — newTotalAssets is now != type(uint256).max
-        vm.prank(vault.valuationManager());
-        vault.updateNewTotalAssets(1);
-
-        // enabling sync redeem should revert because a NAV update is pending
-        vm.prank(vault.safe());
-        vm.expectRevert(EnableSyncRedeemNotAllowed.selector);
-        vault.setIsSyncRedeemAllowed(true);
-    }
-
-    // --- isSyncRedeemAllowed blocks securityCouncilUpdateTotalAssets ---
-
-    function test_securityCouncil_whenSyncRedeemAllowed_cantUpdateNav() public {
-        // let totalAssets lifespan expire so only isSyncRedeemAllowed blocks
-        vm.warp(block.timestamp + 1 days);
-
-        vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
-
+    function test_securityCouncil_whenTotalAssetsValid_cantUpdateNav() public {
         vm.prank(vault.securityCouncil());
         vm.expectRevert(ValuationUpdateNotAllowed.selector);
         vault.securityCouncilUpdateTotalAssets(1);
     }
 
-    function test_securityCouncil_disableSyncOperations_clearsSyncRedeemAllowed() public {
+    function test_securityCouncil_whenTotalAssetsExpired_canUpdateNav() public {
         vm.warp(block.timestamp + 1 days);
-
-        vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
-
-        // verify blocked
-        vm.prank(vault.securityCouncil());
-        vm.expectRevert(ValuationUpdateNotAllowed.selector);
-        vault.securityCouncilUpdateTotalAssets(1);
-
-        // disableSyncOperations should clear isSyncRedeemAllowed
-        vm.prank(vault.safe());
-        vault.disableSyncOperations();
 
         vm.prank(vault.securityCouncil());
         vault.securityCouncilUpdateTotalAssets(1);
-    }
-
-    // --- setIsSyncRedeemAllowed reverts in asyncOnly mode ---
-
-    function test_setIsSyncRedeemAllowed_disableAlsoRevertsWhenNewTotalAssetsPending() public {
-        // enable sync redeem first (while newTotalAssets == max)
-        vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(true);
-
-        // let totalAssets lifespan expire and propose a new NAV
-        vm.warp(block.timestamp + 1 days);
-        // disableSyncOperations so updateNewTotalAssets can go through
-        vm.prank(vault.safe());
-        vault.disableSyncOperations();
-        vm.prank(vault.valuationManager());
-        vault.updateNewTotalAssets(1);
-
-        // trying to disable sync redeem when newTotalAssets is pending succeeds
-        vm.prank(vault.safe());
-        vault.setIsSyncRedeemAllowed(false);
     }
 }

--- a/test/v0.6.0/WhitelistableStorageCollision.t.sol
+++ b/test/v0.6.0/WhitelistableStorageCollision.t.sol
@@ -55,12 +55,12 @@ contract TestWhitelistableStorageCollision is BaseTest {
         VaultHelper_v0_5_1 vault = VaultHelper_v0_5_1(
             OptinProxyFactory_v0_5_0(address(factory))
                 .createVaultProxy({
-                    _logic: address(0),
-                    _initialOwner: initStruct.admin,
-                    _initialDelay: 86_400,
-                    _init: initStruct,
-                    salt: salt
-                })
+                _logic: address(0),
+                _initialOwner: initStruct.admin,
+                _initialDelay: 86_400,
+                _init: initStruct,
+                salt: salt
+            })
         );
         DelayProxyAdmin proxyAdmin = DelayProxyAdmin(vm.computeCreateAddress(address(vault), 2));
 


### PR DESCRIPTION
- Add isSyncRedeemAllowed check to securityCouncilUpdateTotalAssets to prevent race condition when sync redemptions are enabled
- Fix previewSyncRedeem returning 0 incorrectly by removing the isTotalAssetsValid check (syncRedeem does not depend on it)
- Add missing @custom:storage-location annotation on RolesStorage in Roles.sol
- Add TotalAssetsExpirationUpdated event emitted on every totalAssetsExpiration mutation (expireTotalAssets, settleDeposit, setAsyncOnly, disableSyncOperations)
- Add SyncOperationsDisabled event for disableSyncOperations