### PR TITLE
fix: unblock OZ upgrade-safety validation for v0.6.0

### DIFF
--- a/src/v0.5.1/Vault.sol
+++ b/src/v0.5.1/Vault.sol
@@ -28,7 +28,6 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 using SafeERC20 for IERC20;
 
-/// @custom:storage-location erc7201:hopper.storage.vault
 /// @param underlying The address of the underlying asset.
 /// @param name The name of the vault and by extension the ERC20 token.
 /// @param symbol The symbol of the vault and by extension the ERC20 token.

--- a/src/v0.6.0/vault/Vault-v0.6.0.sol
+++ b/src/v0.6.0/vault/Vault-v0.6.0.sol
@@ -87,7 +87,9 @@ struct InitStruct {
     bool allowHighWaterMarkReset;
 }
 
-/// @custom:oz-upgrades-from src/v0.5.0/Vault.sol:Vault
+/// @custom:oz-upgrades-unsafe-allow delegatecall
+/// @custom:oz-upgrades-unsafe-allow missing-initializer-call
+/// @custom:oz-upgrades-from src/v0.5.1/Vault.sol:Vault
 contract Vault is ERC7540, Accessable, FeeManager, GuardrailsManager {
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     VaultInit immutable init;


### PR DESCRIPTION
- v0.5.1/Vault.sol: drop stray @custom:storage-location on file-scope InitStruct (rejected by upgrades-core >= 1.44; NatSpec-only).
- v0.6.0/Vault-v0.6.0.sol: repoint @custom:oz-upgrades-from from v0.5.0/Vault.sol (no longer exists) to v0.5.1/Vault.sol.
- v0.6.0/Vault-v0.6.0.sol: allow delegatecall and missing-initializer-call (both intentional: VaultInit is delegatecalled and handles parent init).